### PR TITLE
Add d7 clock divider output for ~2 MHz clock synthesis for MDIO/MDC

### DIFF
--- a/components/ipbus_util/firmware/hdl/ipbus_clock_div.vhd
+++ b/components/ipbus_util/firmware/hdl/ipbus_clock_div.vhd
@@ -40,6 +40,7 @@ use unisim.VComponents.all;
 entity ipbus_clock_div is
 	port(
 		clk: in std_logic;
+		d7: out std_logic;
 		d17: out std_logic;
 		d25: out std_logic;
 		d28: out std_logic
@@ -79,5 +80,6 @@ begin
 	d28 <= cnt(27);
 	d25 <= cnt(24);
 	d17 <= cnt(16);
+	d7 <= cnt(6);
 
 end rtl;


### PR DESCRIPTION
Add one more clock divider output to `ipbus_clock_div` that will produce a ~2 MHz clock when starting from the usual 125 MHz input.
This is needed for configuring the external ethernet PHY device of the Xilinx VCU118 boad using the MDIO/MDC control lines, and can be useful for any other external ethernet device (the specifications of the protocol require the clock frequency to be less than 2.5 MHz).
This change adds no logic at all, so I think it should be completely transparent in any design where the new input is not used.