### PR TITLE
KCU105 example design : Remove unused clock from constraints

### DIFF
--- a/boards/kcu105/base_fw/kcu105_basex/synth/firmware/ucf/kcu105_basex.tcl
+++ b/boards/kcu105/base_fw/kcu105_basex/synth/firmware/ucf/kcu105_basex.tcl
@@ -45,7 +45,7 @@ create_clock -period 6.4 -name eth_refclk [get_ports eth_clk_p]
 # System clock (125MHz)
 create_clock -period 8 -name sysclk [get_ports sysclk_p]
 
-set_clock_groups -asynchronous -group [get_clocks -include_generated_clocks sysclk] -group [get_clocks -include_generated_clocks [get_clocks -filter {name =~ infra/eth/phy/*/rxoutclk*}]] -group [get_clocks -include_generated_clocks [get_clocks -filter {name =~ txoutclk*}]]
+set_clock_groups -asynchronous -group [get_clocks -include_generated_clocks sysclk] -group [get_clocks -include_generated_clocks [get_clocks -filter {name =~ txoutclk*}]]
                                                  
 set_property LOC GTHE3_CHANNEL_X0Y10 [get_cells -hier -filter {name=~infra/eth/*/*GTHE3_CHANNEL_PRIM_INST}]
 


### PR DESCRIPTION
This pull request addresses issue #62 - i.e. it removes the mention of an used clock from the KCU105 example design's async clock group declaration.