### PR TITLE
Update sim infra to have output clock of configurable frequency

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -236,8 +236,6 @@ run_sim:vivado2016.4:modelsim10.5:
     - docker-device-net-tun
     - xilinx-tools
   stage: quick_checks
-  only:
-    - /^pull-requests.[0-9]+$/
   variables:
     VIVADO_VERSION: "2016.4"
     IPBB_SIMLIB_BASE: /scratch/xilinx-simlibs/modelsim_10.5

--- a/boards/sim/firmware/hdl/sim_infra.vhd
+++ b/boards/sim/firmware/hdl/sim_infra.vhd
@@ -36,6 +36,9 @@ use IEEE.STD_LOGIC_1164.ALL;
 use work.ipbus.all;
 
 entity sim_infra is
+	generic(
+		CLK_AUX_FREQ: real := 40.0
+	);
 	port(
 		clk_ipb_o: out std_logic; -- IPbus clock
 		rst_ipb_o: out std_logic;
@@ -65,7 +68,7 @@ begin
 		port map(
 			clko125 => clk125,
 			clko25 => clk_ipb_i,
-			clko40 => clk_aux_o,
+			clko_aux => clk_aux_o,
 			nuke => nuke,
 			soft_rst => soft_rst,
 			rsto => rst,

--- a/boards/sim/firmware/hdl/sim_infra.vhd
+++ b/boards/sim/firmware/hdl/sim_infra.vhd
@@ -23,9 +23,6 @@
 --
 ---------------------------------------------------------------------------------
 
-
--- sp601_infra
---
 -- All board-specific stuff goes here.
 --
 -- Dave Newbold, June 2013
@@ -42,7 +39,7 @@ entity sim_infra is
 	port(
 		clk_ipb_o: out std_logic; -- IPbus clock
 		rst_ipb_o: out std_logic;
-		clk_aux_o: out std_logic; -- 40MHz generated clock
+		clk_aux_o: out std_logic; -- Aux generated clock
 		rst_aux_o: out std_logic;
 		nuke: in std_logic; -- The signal of doom
 		soft_rst: in std_logic; -- The signal of lesser doom

--- a/components/ipbus_util/firmware/sim_hdl/clock_sim.vhd
+++ b/components/ipbus_util/firmware/sim_hdl/clock_sim.vhd
@@ -36,10 +36,13 @@ use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
 entity clock_sim is
+	generic(
+		CLK_AUX_FREQ: real := 40.0
+	);
 	port(
 		clko125: out std_logic;
 		clko25: out std_logic;
-		clko40: out std_logic;
+		clko_aux: out std_logic;
 		clko62_5: out std_logic;
 		nuke: in std_logic;
 		soft_rst: in std_logic;
@@ -51,7 +54,7 @@ end clock_sim;
 
 architecture behavioural of clock_sim is
 
-	signal clk125, clk25, clk40, clk62_5, nuke_del, srst: std_logic := '0';
+	signal clk125, clk25, clk_aux, clk62_5, nuke_del, srst: std_logic := '0';
 	signal reset_vec: std_logic_vector(3 downto 0) := X"f";
 	signal rctr: unsigned(3 downto 0) := "0000";
 
@@ -59,12 +62,12 @@ begin
 
 	clk125 <= not clk125 after 4 ns;
 	clk25 <= not clk25 after 20 ns;
-	clk40 <= not clk40 after 12.5 ns;
+	clk_aux <= not clk_aux after ((1000.0 / CLK_AUX_FREQ) / 2.0) ns;
 	clk62_5 <= not clk62_5 after 8 ns;
 	
 	clko125 <= clk125;
 	clko25 <= clk25;
-	clko40 <= clk40;
+	clko_aux <= clk_aux;
 	clko62_5 <= clk62_5;
 	
 	srst <= '1' when rctr /= "0000" else '0';

--- a/components/ipbus_util/firmware/sim_hdl/clock_sim.vhd
+++ b/components/ipbus_util/firmware/sim_hdl/clock_sim.vhd
@@ -62,7 +62,7 @@ begin
 
 	clk125 <= not clk125 after 4 ns;
 	clk25 <= not clk25 after 20 ns;
-	clk_aux <= not clk_aux after ((1000.0 / CLK_AUX_FREQ) / 2.0) ns;
+	clk_aux <= not clk_aux after (500000.0 / CLK_AUX_FREQ) * 1 ps;
 	clk62_5 <= not clk62_5 after 8 ns;
 	
 	clko125 <= clk125;


### PR DESCRIPTION
This pull request updates the 40MHz output clock from the sim infra to make the frequency configurable (changing port name in the process); it solves issue #72