### PR TITLE
Slave ipbus_ctrs_ported : Add missing 'READ_ONLY' generic

### DIFF
--- a/components/ipbus_slaves/firmware/hdl/ipbus_ctrs_ported.vhd
+++ b/components/ipbus_slaves/firmware/hdl/ipbus_ctrs_ported.vhd
@@ -46,7 +46,8 @@ entity ipbus_ctrs_ported is
 		N_CTRS: natural := 1;
 		CTR_WDS: positive := 1;
 		LIMIT: boolean := true;
-		RST_ON_READ: boolean := false
+		RST_ON_READ: boolean := false;
+		READ_ONLY: boolean := true
 	);
 	port(
 		ipb_clk: in std_logic;


### PR DESCRIPTION
This pull request fixes a bug from PR #65 - omission of `READ_ONLY` generic from declaration of the `ipbus_ctrs_ported` entity. Part of issue #64