### PR TITLE
Add ZCU102 basex example design

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -166,6 +166,17 @@ quick_check:kcu105_basex__2018.2:
     VIVADO_VERSION: "2018.2"
     PROJ: kcu105_basex
 
+quick_check:zcu102_basex__2017.4:
+  <<: *template_vivado_quick_check
+  variables:
+    VIVADO_VERSION: "2017.4"
+    PROJ: zcu102_basex
+quick_check:zcu102_basex__2018.2:
+  <<: *template_vivado_quick_check
+  variables:
+    VIVADO_VERSION: "2018.2"
+    PROJ: zcu102_basex
+
 
 
 build:enclustra_ax3_pm3_a35__2017.4:
@@ -232,6 +243,21 @@ build:kcu105_basex__2018.2:
     VIVADO_VERSION: "2018.2"
   dependencies:
     - quick_check:kcu105_basex__2018.2
+
+build:zcu102_basex__2017.4:
+  <<: *template_vivado_build
+  variables:
+    VIVADO_VERSION: "2017.4"
+  dependencies:
+    - quick_check:zcu102_basex__2017.4
+build:zcu102_basex__2018.2:
+  <<: *template_vivado_build
+  variables:
+    VIVADO_VERSION: "2018.2"
+  dependencies:
+    - quick_check:zcu102_basex__2018.2
+
+
 
 run_sim:vivado2017.4:modelsim10.6c:
   <<: *template_base

--- a/boards/zcu102/base_fw/zcu102_basex/synth/firmware/cfg/settings_ku.tcl
+++ b/boards/zcu102/base_fw/zcu102_basex/synth/firmware/cfg/settings_ku.tcl
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 #-------------------------------------------------------------------------------
 #
 #   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
@@ -25,41 +24,8 @@
 #-------------------------------------------------------------------------------
 
 
-
-
-SH_SOURCE=${BASH_SOURCE}
-IPBUS_PATH=$(cd $(dirname ${SH_SOURCE})/../.. && pwd)
-WORK_ROOT=$(cd ${IPBUS_PATH}/../.. && pwd)
-
-PROJECTS=(enclustra_ax3_pm3_a35 enclustra_ax3_pm3_a50 kc705_basex kc705_gmii kcu105_basex zcu102_basex)
-
-if (( $# != 1 )); then
-  echo "No project specified."
-  echo "Available projects:" $(printf "'%s' " "${PROJECTS[@]}")
-
-  exit -1
-fi
-PROJ=$1
-if [[ ! " ${PROJECTS[@]} " =~ " ${PROJ} " ]]; then
-  # whatever you want to do when arr doesn't contain value
-  echo "Project ${PROJ} not known."
-  echo "Available projects: ${PROJECTS[@]}"
-  exit -1
-fi
-
-# Stop on the first error
-set -e
-# set -x
-
-cd ${WORK_ROOT}
-rm -rf proj/${PROJ}
-echo "#------------------------------------------------"
-echo "Building Project ${PROJ}"
-echo "#------------------------------------------------"
-ipbb proj create vivado -t top_${PROJ}.dep ${PROJ} ipbus-firmware:projects/example
-ipbb vivado -p ${PROJ} make-project
-ipbb vivado -p ${PROJ} check-syntax
-
-
-
-exit 0
+set obj [get_projects top]
+set_property "default_lib" "xil_defaultlib" $obj
+set_property "simulator_language" "Mixed" $obj
+set_property "source_mgmt_mode" "DisplayOnly" $obj
+set_property "target_language" "VHDL" $obj

--- a/boards/zcu102/base_fw/zcu102_basex/synth/firmware/cfg/zcu102_basex.dep
+++ b/boards/zcu102/base_fw/zcu102_basex/synth/firmware/cfg/zcu102_basex.dep
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 #-------------------------------------------------------------------------------
 #
 #   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
@@ -24,42 +23,10 @@
 #
 #-------------------------------------------------------------------------------
 
-
-
-
-SH_SOURCE=${BASH_SOURCE}
-IPBUS_PATH=$(cd $(dirname ${SH_SOURCE})/../.. && pwd)
-WORK_ROOT=$(cd ${IPBUS_PATH}/../.. && pwd)
-
-PROJECTS=(enclustra_ax3_pm3_a35 enclustra_ax3_pm3_a50 kc705_basex kc705_gmii kcu105_basex zcu102_basex)
-
-if (( $# != 1 )); then
-  echo "No project specified."
-  echo "Available projects:" $(printf "'%s' " "${PROJECTS[@]}")
-
-  exit -1
-fi
-PROJ=$1
-if [[ ! " ${PROJECTS[@]} " =~ " ${PROJ} " ]]; then
-  # whatever you want to do when arr doesn't contain value
-  echo "Project ${PROJ} not known."
-  echo "Available projects: ${PROJECTS[@]}"
-  exit -1
-fi
-
-# Stop on the first error
-set -e
-# set -x
-
-cd ${WORK_ROOT}
-rm -rf proj/${PROJ}
-echo "#------------------------------------------------"
-echo "Building Project ${PROJ}"
-echo "#------------------------------------------------"
-ipbb proj create vivado -t top_${PROJ}.dep ${PROJ} ipbus-firmware:projects/example
-ipbb vivado -p ${PROJ} make-project
-ipbb vivado -p ${PROJ} check-syntax
-
-
-
-exit 0
+setup settings_ku.tcl
+include zu9.dep
+src zcu102_basex.vhd
+include zcu102_basex_infra.dep
+include -c components/ipbus_util ipbus_example.dep
+src -c components/ipbus_core ipbus_package.vhd
+src --cd ../ucf zcu102_basex.tcl

--- a/boards/zcu102/base_fw/zcu102_basex/synth/firmware/cfg/zcu102_basex.dep
+++ b/boards/zcu102/base_fw/zcu102_basex/synth/firmware/cfg/zcu102_basex.dep
@@ -25,8 +25,7 @@
 
 setup settings_ku.tcl
 include zu9.dep
-src zcu102_basex.vhd
+src top_zcu102_basex.vhd
 include zcu102_basex_infra.dep
-include -c components/ipbus_util ipbus_example.dep
 src -c components/ipbus_core ipbus_package.vhd
 src --cd ../ucf zcu102_basex.tcl

--- a/boards/zcu102/base_fw/zcu102_basex/synth/firmware/cfg/zcu102_basex_infra.dep
+++ b/boards/zcu102/base_fw/zcu102_basex/synth/firmware/cfg/zcu102_basex_infra.dep
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 #-------------------------------------------------------------------------------
 #
 #   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
@@ -25,41 +24,8 @@
 #-------------------------------------------------------------------------------
 
 
-
-
-SH_SOURCE=${BASH_SOURCE}
-IPBUS_PATH=$(cd $(dirname ${SH_SOURCE})/../.. && pwd)
-WORK_ROOT=$(cd ${IPBUS_PATH}/../.. && pwd)
-
-PROJECTS=(enclustra_ax3_pm3_a35 enclustra_ax3_pm3_a50 kc705_basex kc705_gmii kcu105_basex zcu102_basex)
-
-if (( $# != 1 )); then
-  echo "No project specified."
-  echo "Available projects:" $(printf "'%s' " "${PROJECTS[@]}")
-
-  exit -1
-fi
-PROJ=$1
-if [[ ! " ${PROJECTS[@]} " =~ " ${PROJ} " ]]; then
-  # whatever you want to do when arr doesn't contain value
-  echo "Project ${PROJ} not known."
-  echo "Available projects: ${PROJECTS[@]}"
-  exit -1
-fi
-
-# Stop on the first error
-set -e
-# set -x
-
-cd ${WORK_ROOT}
-rm -rf proj/${PROJ}
-echo "#------------------------------------------------"
-echo "Building Project ${PROJ}"
-echo "#------------------------------------------------"
-ipbb proj create vivado -t top_${PROJ}.dep ${PROJ} ipbus-firmware:projects/example
-ipbb vivado -p ${PROJ} make-project
-ipbb vivado -p ${PROJ} check-syntax
-
-
-
-exit 0
+src zcu102_basex_infra.vhd
+src -c components/ipbus_util clocks_us_serdes.vhd ipbus_clock_div.vhd led_stretcher.vhd
+include -c components/ipbus_core
+include -c components/ipbus_eth zcu102_basex.dep
+src -c components/ipbus_core ipbus_fabric_sel.vhd ipbus_package.vhd

--- a/boards/zcu102/base_fw/zcu102_basex/synth/firmware/cfg/zu9.dep
+++ b/boards/zcu102/base_fw/zcu102_basex/synth/firmware/cfg/zu9.dep
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 #-------------------------------------------------------------------------------
 #
 #   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
@@ -25,41 +24,8 @@
 #-------------------------------------------------------------------------------
 
 
-
-
-SH_SOURCE=${BASH_SOURCE}
-IPBUS_PATH=$(cd $(dirname ${SH_SOURCE})/../.. && pwd)
-WORK_ROOT=$(cd ${IPBUS_PATH}/../.. && pwd)
-
-PROJECTS=(enclustra_ax3_pm3_a35 enclustra_ax3_pm3_a50 kc705_basex kc705_gmii kcu105_basex zcu102_basex)
-
-if (( $# != 1 )); then
-  echo "No project specified."
-  echo "Available projects:" $(printf "'%s' " "${PROJECTS[@]}")
-
-  exit -1
-fi
-PROJ=$1
-if [[ ! " ${PROJECTS[@]} " =~ " ${PROJ} " ]]; then
-  # whatever you want to do when arr doesn't contain value
-  echo "Project ${PROJ} not known."
-  echo "Available projects: ${PROJECTS[@]}"
-  exit -1
-fi
-
-# Stop on the first error
-set -e
-# set -x
-
-cd ${WORK_ROOT}
-rm -rf proj/${PROJ}
-echo "#------------------------------------------------"
-echo "Building Project ${PROJ}"
-echo "#------------------------------------------------"
-ipbb proj create vivado -t top_${PROJ}.dep ${PROJ} ipbus-firmware:projects/example
-ipbb vivado -p ${PROJ} make-project
-ipbb vivado -p ${PROJ} check-syntax
-
-
-
-exit 0
+@device_family = "zynqup"
+@device_name = "xczu9eg"
+@device_package = "-ffvb1156"
+@device_speed = "-2-e"
+@boardname = "zcu102_basex"

--- a/boards/zcu102/base_fw/zcu102_basex/synth/firmware/hdl/top_zcu102_basex.vhd
+++ b/boards/zcu102/base_fw/zcu102_basex/synth/firmware/hdl/top_zcu102_basex.vhd
@@ -54,7 +54,7 @@ end top;
 
 architecture rtl of top is
 
-	signal clk_ipb, rst_ipb, nuke, soft_rst, userled: std_logic;
+	signal clk_ipb, rst_ipb, clk_aux, rst_aux, nuke, soft_rst, userled: std_logic;
 	signal mac_addr: std_logic_vector(47 downto 0);
 	signal ip_addr: std_logic_vector(31 downto 0);
 	signal ipb_out: ipb_wbus;
@@ -77,6 +77,8 @@ begin
 			sfp_los => '0',
 			clk_ipb_o => clk_ipb,
 			rst_ipb_o => rst_ipb,
+			clk_aux_o => clk_aux,
+			rst_aux_o => rst_aux,
 			nuke => nuke,
 			soft_rst => soft_rst,
 			leds => leds(1 downto 0),
@@ -94,12 +96,14 @@ begin
 -- ipbus slaves live in the entity below, and can expose top-level ports
 -- The ipbus fabric is instantiated within.
 
-	slaves: entity work.ipbus_example
+	payload: entity work.payload
 		port map(
 			ipb_clk => clk_ipb,
 			ipb_rst => rst_ipb,
 			ipb_in => ipb_out,
 			ipb_out => ipb_in,
+			clk => clk_aux,
+			rst => rst_aux,
 			nuke => nuke,
 			soft_rst => soft_rst,
 			userled => userled

--- a/boards/zcu102/base_fw/zcu102_basex/synth/firmware/hdl/zcu102_basex.vhd
+++ b/boards/zcu102/base_fw/zcu102_basex/synth/firmware/hdl/zcu102_basex.vhd
@@ -1,0 +1,108 @@
+---------------------------------------------------------------------------------
+--
+--   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
+--
+--   Licensed under the Apache License, Version 2.0 (the "License");
+--   you may not use this file except in compliance with the License.
+--   You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--   Unless required by applicable law or agreed to in writing, software
+--   distributed under the License is distributed on an "AS IS" BASIS,
+--   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--   See the License for the specific language governing permissions and
+--   limitations under the License.
+--
+--                                     - - -
+--
+--   Additional information about ipbus-firmare and the list of ipbus-firmware
+--   contacts are available at
+--
+--       https://ipbus.web.cern.ch/ipbus
+--
+---------------------------------------------------------------------------------
+
+
+-- Top-level design for ipbus demo
+--
+-- This version is for ZCU102 eval board, using SFP ethernet interface
+--
+-- You must edit this file to set the IP and MAC addresses
+--
+-- Dave Newbold, 24/10/16
+
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+
+use work.ipbus.ALL;
+
+entity top is port(
+		sysclk_p: in std_logic;
+		sysclk_n: in std_logic;
+		eth_clk_p: in std_logic; -- 125MHz MGT clock
+		eth_clk_n: in std_logic;
+		eth_rx_p: in std_logic; -- Ethernet MGT input
+		eth_rx_n: in std_logic;
+		eth_tx_p: out std_logic; -- Ethernet MGT output
+		eth_tx_n: out std_logic;
+		leds: out std_logic_vector(7 downto 0); -- status LEDs
+		dip_sw: in std_logic_vector(3 downto 0) -- switches
+	);
+
+end top;
+
+architecture rtl of top is
+
+	signal clk_ipb, rst_ipb, nuke, soft_rst, userled: std_logic;
+	signal mac_addr: std_logic_vector(47 downto 0);
+	signal ip_addr: std_logic_vector(31 downto 0);
+	signal ipb_out: ipb_wbus;
+	signal ipb_in: ipb_rbus;
+	
+begin
+
+-- Infrastructure
+
+	infra: entity work.zcu102_basex_infra
+		port map(
+			sysclk_p => sysclk_p,
+			sysclk_n => sysclk_n,
+			eth_clk_p => eth_clk_p,
+			eth_clk_n => eth_clk_n,
+			eth_tx_p => eth_tx_p,
+			eth_tx_n => eth_tx_n,
+			eth_rx_p => eth_rx_p,
+			eth_rx_n => eth_rx_n,
+			sfp_los => '0',
+			clk_ipb_o => clk_ipb,
+			rst_ipb_o => rst_ipb,
+			nuke => nuke,
+			soft_rst => soft_rst,
+			leds => leds(1 downto 0),
+			mac_addr => mac_addr,
+			ip_addr => ip_addr,
+			ipb_in => ipb_in,
+			ipb_out => ipb_out
+		);
+		
+	leds(7 downto 2) <= "00000" & userled;
+		
+	mac_addr <= X"020ddba1151" & dip_sw; -- Careful here, arbitrary addresses do not always work
+	ip_addr <= X"c0a8c81" & dip_sw; -- 192.168.200.16+n
+
+-- ipbus slaves live in the entity below, and can expose top-level ports
+-- The ipbus fabric is instantiated within.
+
+	slaves: entity work.ipbus_example
+		port map(
+			ipb_clk => clk_ipb,
+			ipb_rst => rst_ipb,
+			ipb_in => ipb_out,
+			ipb_out => ipb_in,
+			nuke => nuke,
+			soft_rst => soft_rst,
+			userled => userled
+		);
+
+end rtl;

--- a/boards/zcu102/base_fw/zcu102_basex/synth/firmware/hdl/zcu102_basex_infra.vhd
+++ b/boards/zcu102/base_fw/zcu102_basex/synth/firmware/hdl/zcu102_basex_infra.vhd
@@ -1,0 +1,169 @@
+---------------------------------------------------------------------------------
+--
+--   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
+--
+--   Licensed under the Apache License, Version 2.0 (the "License");
+--   you may not use this file except in compliance with the License.
+--   You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--   Unless required by applicable law or agreed to in writing, software
+--   distributed under the License is distributed on an "AS IS" BASIS,
+--   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--   See the License for the specific language governing permissions and
+--   limitations under the License.
+--
+--                                     - - -
+--
+--   Additional information about ipbus-firmare and the list of ipbus-firmware
+--   contacts are available at
+--
+--       https://ipbus.web.cern.ch/ipbus
+--
+---------------------------------------------------------------------------------
+
+
+-- kc705_basex_infra
+--
+-- All board-specific stuff goes here.
+--
+-- Dave Newbold, June 2013
+
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+
+library unisim;
+use unisim.VComponents.all;
+
+use work.ipbus.all;
+
+entity zcu102_basex_infra is
+	port(
+		sysclk_p: in std_logic;
+		sysclk_n: in std_logic;
+		eth_clk_p: in std_logic; -- 125MHz MGT clock
+		eth_clk_n: in std_logic;
+		eth_rx_p: in std_logic; -- Ethernet MGT input
+		eth_rx_n: in std_logic;
+		eth_tx_p: out std_logic; -- Ethernet MGT output
+		eth_tx_n: out std_logic;
+		sfp_los: in std_logic;
+		clk_ipb_o: out std_logic; -- IPbus clock
+		rst_ipb_o: out std_logic;
+		clk_aux_o: out std_logic; -- 40MHz generated clock
+		rst_aux_o: out std_logic;
+		nuke: in std_logic; -- The signal of doom
+		soft_rst: in std_logic; -- The signal of lesser doom
+		leds: out std_logic_vector(1 downto 0); -- status LEDs
+		mac_addr: in std_logic_vector(47 downto 0); -- MAC address
+		ip_addr: in std_logic_vector(31 downto 0); -- IP address
+		ipb_in: in ipb_rbus; -- ipbus
+		ipb_out: out ipb_wbus
+	);
+
+end zcu102_basex_infra;
+
+architecture rtl of zcu102_basex_infra is
+
+	signal sysclk, clk125, clk_ipb, clk_ipb_i, locked, clk_locked, eth_locked, rst125, rst_ipb, rst_ipb_ctrl, rst_eth, onehz, pkt: std_logic;
+	signal mac_tx_data, mac_rx_data: std_logic_vector(7 downto 0);
+	signal mac_tx_valid, mac_tx_last, mac_tx_error, mac_tx_ready, mac_rx_valid, mac_rx_last, mac_rx_error: std_logic;
+	signal led_p: std_logic_vector(0 downto 0);
+	
+begin
+
+	ibuf: IBUFDS
+		port map(
+			i => sysclk_p,
+			ib => sysclk_n,
+			o => sysclk
+		);
+
+--	DCM clock generation for internal bus, ethernet
+
+	clocks: entity work.clocks_us_serdes
+		port map(
+			clki_fr => sysclk,
+			clki_125 => clk125,
+			clko_ipb => clk_ipb_i,
+			eth_locked => eth_locked,
+			locked => clk_locked,
+			nuke => nuke,
+			soft_rst => soft_rst,
+			rsto_125 => rst125,
+			rsto_ipb => rst_ipb,
+			rsto_eth => rst_eth,
+			rsto_ipb_ctrl => rst_ipb_ctrl,
+			onehz => onehz
+		);
+
+	clk_ipb <= clk_ipb_i; -- Best to align delta delays on all clocks for simulation
+	clk_ipb_o <= clk_ipb_i;
+	rst_ipb_o <= rst_ipb;
+
+	locked <= clk_locked and eth_locked;
+	
+	stretch: entity work.led_stretcher
+		generic map(
+			WIDTH => 1
+		)
+		port map(
+			clk => clk125,
+			d(0) => pkt,
+			q => led_p
+		);
+
+	leds <= (led_p(0), locked and onehz);
+	
+-- Ethernet MAC core and PHY interface
+	
+	eth: entity work.eth_us_1000basex
+		port map(
+			gt_clkp => eth_clk_p,
+			gt_clkn => eth_clk_n,
+			gt_txp => eth_tx_p,
+			gt_txn => eth_tx_n,
+			gt_rxp => eth_rx_p,
+			gt_rxn => eth_rx_n,
+			sfp_los => sfp_los,
+			clk125_out => clk125,
+			indep_clk_in => clk_ipb, -- Might as well use the IPB clock for this
+			rsti => rst_eth,
+			locked => eth_locked,
+			tx_data => mac_tx_data,
+			tx_valid => mac_tx_valid,
+			tx_last => mac_tx_last,
+			tx_error => mac_tx_error,
+			tx_ready => mac_tx_ready,
+			rx_data => mac_rx_data,
+			rx_valid => mac_rx_valid,
+			rx_last => mac_rx_last,
+			rx_error => mac_rx_error
+		);
+	
+-- ipbus control logic
+
+	ipbus: entity work.ipbus_ctrl
+		port map(
+			mac_clk => clk125,
+			rst_macclk => rst125,
+			ipb_clk => clk_ipb,
+			rst_ipb => rst_ipb_ctrl,
+			mac_rx_data => mac_rx_data,
+			mac_rx_valid => mac_rx_valid,
+			mac_rx_last => mac_rx_last,
+			mac_rx_error => mac_rx_error,
+			mac_tx_data => mac_tx_data,
+			mac_tx_valid => mac_tx_valid,
+			mac_tx_last => mac_tx_last,
+			mac_tx_error => mac_tx_error,
+			mac_tx_ready => mac_tx_ready,
+			ipb_out => ipb_out,
+			ipb_in => ipb_in,
+			mac_addr => mac_addr,
+			ip_addr => ip_addr,
+			pkt => pkt
+		);
+
+end rtl;

--- a/boards/zcu102/base_fw/zcu102_basex/synth/firmware/hdl/zcu102_basex_infra.vhd
+++ b/boards/zcu102/base_fw/zcu102_basex/synth/firmware/hdl/zcu102_basex_infra.vhd
@@ -66,7 +66,7 @@ end zcu102_basex_infra;
 
 architecture rtl of zcu102_basex_infra is
 
-	signal sysclk, clk125, clk_ipb, clk_ipb_i, locked, clk_locked, eth_locked, rst125, rst_ipb, rst_ipb_ctrl, rst_eth, onehz, pkt: std_logic;
+	signal sysclk, clk125, clk_ipb, clk_ipb_i, clk_aux, locked, clk_locked, eth_locked, rst125, rst_ipb, rst_ipb_ctrl, rst_eth, rst_aux, onehz, pkt: std_logic;
 	signal mac_tx_data, mac_rx_data: std_logic_vector(7 downto 0);
 	signal mac_tx_valid, mac_tx_last, mac_tx_error, mac_tx_ready, mac_rx_valid, mac_rx_last, mac_rx_error: std_logic;
 	signal led_p: std_logic_vector(0 downto 0);
@@ -87,6 +87,7 @@ begin
 			clki_fr => sysclk,
 			clki_125 => clk125,
 			clko_ipb => clk_ipb_i,
+			clko_aux => clk_aux,
 			eth_locked => eth_locked,
 			locked => clk_locked,
 			nuke => nuke,
@@ -95,12 +96,15 @@ begin
 			rsto_ipb => rst_ipb,
 			rsto_eth => rst_eth,
 			rsto_ipb_ctrl => rst_ipb_ctrl,
+			rsto_aux => rst_aux,
 			onehz => onehz
 		);
 
 	clk_ipb <= clk_ipb_i; -- Best to align delta delays on all clocks for simulation
 	clk_ipb_o <= clk_ipb_i;
 	rst_ipb_o <= rst_ipb;
+	clk_aux_o <= clk_aux;
+	rst_aux_o <= rst_aux;
 
 	locked <= clk_locked and eth_locked;
 	

--- a/boards/zcu102/base_fw/zcu102_basex/synth/firmware/ucf/zcu102_basex.tcl
+++ b/boards/zcu102/base_fw/zcu102_basex/synth/firmware/ucf/zcu102_basex.tcl
@@ -1,0 +1,82 @@
+#-------------------------------------------------------------------------------
+#
+#   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#                                     - - -
+#
+#   Additional information about ipbus-firmare and the list of ipbus-firmware
+#   contacts are available at
+#
+#       https://ipbus.web.cern.ch/ipbus
+#
+#-------------------------------------------------------------------------------
+
+
+set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
+
+proc false_path {patt clk} {
+    set p [get_ports -quiet $patt -filter {direction != out}]
+    if {[llength $p] != 0} {
+        set_input_delay 0 -clock [get_clocks $clk] [get_ports $patt -filter {direction != out}]
+        set_false_path -from [get_ports $patt -filter {direction != out}]
+    }
+    set p [get_ports -quiet $patt -filter {direction != in}]
+    if {[llength $p] != 0} {
+       	set_output_delay 0 -clock [get_clocks $clk] [get_ports $patt -filter {direction != in}]
+	    set_false_path -to [get_ports $patt -filter {direction != in}]
+	}
+}
+
+# Ethernet RefClk (156MHz, scaled to 125 MHz later)
+create_clock -period 6.4 -name eth_refclk [get_ports eth_clk_p]
+
+# System clock (125MHz)
+create_clock -period 8 -name sysclk [get_ports sysclk_p]
+
+set_clock_groups -asynchronous -group [get_clocks -include_generated_clocks sysclk] -group [get_clocks -include_generated_clocks [get_clocks -filter {name =~ txoutclk*}]]
+
+# use the top left cage (SFP0) in the onboard quad SFP+ module. eth_tx_p on pin E4, bank 230
+set_property LOC GTHE4_CHANNEL_X1Y12 [get_cells -hier -filter {name=~infra/eth/*/*GTHE4_CHANNEL_PRIM_INST}]
+
+# MGT reference clock for bank 230
+set_property PACKAGE_PIN C8 [get_ports eth_clk_p]
+set_property PACKAGE_PIN C7 [get_ports eth_clk_n]
+
+# MGT reference clock for bank 129
+#set_property PACKAGE_PIN L27 [get_ports eth_clk_p]
+#set_property PACKAGE_PIN L28 [get_ports eth_clk_n]
+
+set_property IOSTANDARD LVDS_25 [get_ports {sysclk_*}]
+set_property PACKAGE_PIN G21 [get_ports sysclk_p]
+set_property PACKAGE_PIN F21 [get_ports sysclk_n]
+
+set_property IOSTANDARD LVCMOS33 [get_ports {leds[*]}]
+set_property SLEW SLOW [get_ports {leds[*]}]
+set_property PACKAGE_PIN AG14 [get_ports {leds[0]}]
+set_property PACKAGE_PIN AF13 [get_ports {leds[1]}]
+set_property PACKAGE_PIN AE13 [get_ports {leds[2]}]
+set_property PACKAGE_PIN AJ14 [get_ports {leds[3]}]
+set_property PACKAGE_PIN AJ15 [get_ports {leds[4]}]
+set_property PACKAGE_PIN AH13 [get_ports {leds[5]}]
+set_property PACKAGE_PIN AH14 [get_ports {leds[6]}]
+set_property PACKAGE_PIN AL12 [get_ports {leds[7]}]
+false_path {leds[*]} sysclk
+
+set_property IOSTANDARD LVCMOS33 [get_ports {dip_sw[*]}]
+set_property PACKAGE_PIN AN14 [get_ports {dip_sw[0]}]
+set_property PACKAGE_PIN AP14 [get_ports {dip_sw[1]}]
+set_property PACKAGE_PIN AM14 [get_ports {dip_sw[2]}]
+set_property PACKAGE_PIN AN13 [get_ports {dip_sw[3]}]
+false_path {dip_sw[*]} sysclk

--- a/components/ipbus_eth/firmware/cfg/zcu102_basex.dep
+++ b/components/ipbus_eth/firmware/cfg/zcu102_basex.dep
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 #-------------------------------------------------------------------------------
 #
 #   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
@@ -25,41 +24,8 @@
 #-------------------------------------------------------------------------------
 
 
+# Dependencies for the ethernet gubbins on a ku part
 
-
-SH_SOURCE=${BASH_SOURCE}
-IPBUS_PATH=$(cd $(dirname ${SH_SOURCE})/../.. && pwd)
-WORK_ROOT=$(cd ${IPBUS_PATH}/../.. && pwd)
-
-PROJECTS=(enclustra_ax3_pm3_a35 enclustra_ax3_pm3_a50 kc705_basex kc705_gmii kcu105_basex zcu102_basex)
-
-if (( $# != 1 )); then
-  echo "No project specified."
-  echo "Available projects:" $(printf "'%s' " "${PROJECTS[@]}")
-
-  exit -1
-fi
-PROJ=$1
-if [[ ! " ${PROJECTS[@]} " =~ " ${PROJ} " ]]; then
-  # whatever you want to do when arr doesn't contain value
-  echo "Project ${PROJ} not known."
-  echo "Available projects: ${PROJECTS[@]}"
-  exit -1
-fi
-
-# Stop on the first error
-set -e
-# set -x
-
-cd ${WORK_ROOT}
-rm -rf proj/${PROJ}
-echo "#------------------------------------------------"
-echo "Building Project ${PROJ}"
-echo "#------------------------------------------------"
-ipbb proj create vivado -t top_${PROJ}.dep ${PROJ} ipbus-firmware:projects/example
-ipbb vivado -p ${PROJ} make-project
-ipbb vivado -p ${PROJ} check-syntax
-
-
-
-exit 0
+src eth_us_1000basex.vhd emac_hostbus_decl.vhd
+src ../cgn/temac_gbe_v9_0.xci
+src ../cgn/gig_ethernet_pcs_pma_basex_156_25.xci

--- a/projects/example/firmware/cfg/top_zcu102_basex.dep
+++ b/projects/example/firmware/cfg/top_zcu102_basex.dep
@@ -1,2 +1,28 @@
+#-------------------------------------------------------------------------------
+#
+#   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#                                     - - -
+#
+#   Additional information about ipbus-firmare and the list of ipbus-firmware
+#   contacts are available at
+#
+#       https://ipbus.web.cern.ch/ipbus
+#
+#-------------------------------------------------------------------------------
+
+
 include -c boards/zcu102/base_fw/zcu102_basex/synth zcu102_basex.dep
 include -c components/ipbus_util ipbus_example.dep

--- a/projects/example/firmware/cfg/top_zcu102_basex.dep
+++ b/projects/example/firmware/cfg/top_zcu102_basex.dep
@@ -1,0 +1,2 @@
+include -c boards/zcu102/base_fw/zcu102_basex/synth zcu102_basex.dep
+include -c components/ipbus_util ipbus_example.dep

--- a/tests/ci/test_build.sh
+++ b/tests/ci/test_build.sh
@@ -31,7 +31,7 @@ SH_SOURCE=${BASH_SOURCE}
 IPBUS_PATH=$(cd $(dirname ${SH_SOURCE})/../.. && pwd)
 WORK_ROOT=$(cd ${IPBUS_PATH}/../.. && pwd)
 
-PROJECTS=(sim enclustra_ax3_pm3_a35 enclustra_ax3_pm3_a50 kc705_basex kc705_gmii kcu105_basex)
+PROJECTS=(sim enclustra_ax3_pm3_a35 enclustra_ax3_pm3_a50 kc705_basex kc705_gmii kcu105_basex zcu102_basex)
 
 if (( $# != 1 )); then
   echo "No project specified."


### PR DESCRIPTION
This pull request add the ZCU102 example design that's described in issue #76 

It has been validated on the board at RAL - no errors observed in 1 billion-transaction soak test (`Validation` mode of `PerfTester.exe` from uHAL 2.6.x).