### PR TITLE
Fix compilation error ipbus_pipeline

### DIFF
--- a/components/ipbus_core/firmware/hdl/ipbus_pipeline.vhd
+++ b/components/ipbus_core/firmware/hdl/ipbus_pipeline.vhd
@@ -87,6 +87,6 @@ begin
 	
 	m_ipb_out.ipb_ack <= ack_del(latency);
 	m_ipb_out.ipb_err <= err_del(latency);	
-	s_ipb_out.ipb_strobe <= ipbus_in.ipb_strobe and not got_ack;
+	s_ipb_out.ipb_strobe <= m_ipb_in.ipb_strobe and not got_resp;
 	
 end rtl;


### PR DESCRIPTION
This pull request should resolve issue #99 

I have performed a quick test to check that the fix in commit 729e933 resolves the issue. Specifically, I added an instance of `ipbus_pipeline` before the address decoder in `ipbus_example`. Before this change, the simulation example design would not start due to the compilation error; after this change, the simulation example design responds to transactions (both incrementing and non-incrementing) from `PerfTester.exe` without any errors.