### PR TITLE
Resolve 'null range' critical warning in Vivado 2018.3

### DIFF
--- a/components/ipbus_slaves/firmware/hdl/ipbus_dpram.vhd
+++ b/components/ipbus_slaves/firmware/hdl/ipbus_dpram.vhd
@@ -73,7 +73,8 @@ begin
 	process(clk)
 	begin
 		if rising_edge(clk) then
-			ipb_out.ipb_rdata <= (31 - DATA_WIDTH downto 0 => '0') & ram(sel); -- Order of statements is important to infer read-first RAM!
+
+			ipb_out.ipb_rdata <= (DATA_WIDTH - 1 downto 0 => ram(sel), others => '0'); -- Order of statements is important to infer read-first RAM!
 			if ipb_in.ipb_strobe='1' and ipb_in.ipb_write='1' then
 				ram(sel) := ipb_in.ipb_wdata(DATA_WIDTH - 1 downto 0);
 			end if;

--- a/components/ipbus_slaves/firmware/hdl/ipbus_dpram.vhd
+++ b/components/ipbus_slaves/firmware/hdl/ipbus_dpram.vhd
@@ -70,11 +70,15 @@ begin
 
 	sel <= to_integer(unsigned(ipb_in.ipb_addr(ADDR_WIDTH - 1 downto 0)));
 
+	zero_rdata: if DATA_WIDTH /= 32 generate
+		ipb_out.ipb_rdata(31 downto DATA_WIDTH) <= (others => '0');
+	end generate;
+
 	process(clk)
 	begin
 		if rising_edge(clk) then
 
-			ipb_out.ipb_rdata <= (DATA_WIDTH - 1 downto 0 => ram(sel), others => '0'); -- Order of statements is important to infer read-first RAM!
+			ipb_out.ipb_rdata(DATA_WIDTH - 1 downto 0) <= ram(sel); -- Order of statements is important to infer read-first RAM!
 			if ipb_in.ipb_strobe='1' and ipb_in.ipb_write='1' then
 				ram(sel) := ipb_in.ipb_wdata(DATA_WIDTH - 1 downto 0);
 			end if;

--- a/components/ipbus_slaves/firmware/hdl/ipbus_dpram.vhd
+++ b/components/ipbus_slaves/firmware/hdl/ipbus_dpram.vhd
@@ -70,15 +70,11 @@ begin
 
 	sel <= to_integer(unsigned(ipb_in.ipb_addr(ADDR_WIDTH - 1 downto 0)));
 
-	zero_rdata: if DATA_WIDTH /= 32 generate
-		ipb_out.ipb_rdata(31 downto DATA_WIDTH) <= (others => '0');
-	end generate;
-
 	process(clk)
 	begin
 		if rising_edge(clk) then
 
-			ipb_out.ipb_rdata(DATA_WIDTH - 1 downto 0) <= ram(sel); -- Order of statements is important to infer read-first RAM!
+			ipb_out.ipb_rdata <= std_logic_vector(to_unsigned(0, 32 - DATA_WIDTH)) & ram(sel); -- Order of statements is important to infer read-first RAM!
 			if ipb_in.ipb_strobe='1' and ipb_in.ipb_write='1' then
 				ram(sel) := ipb_in.ipb_wdata(DATA_WIDTH - 1 downto 0);
 			end if;

--- a/components/ipbus_slaves/firmware/hdl/ipbus_ported_dpram.vhd
+++ b/components/ipbus_slaves/firmware/hdl/ipbus_ported_dpram.vhd
@@ -105,8 +105,8 @@ begin
 	ipb_out.ipb_ack <= ipb_in.ipb_strobe;
 	ipb_out.ipb_err <= '0';
 	ipb_out.ipb_rdata <= (31 - ADDR_WIDTH downto 0 => '0') & std_logic_vector(ptr) when ipb_in.ipb_addr(0)='0'
-		else (31 - DATA_WIDTH downto 0 => '0') & data;
-	
+		else (DATA_WIDTH - 1 downto 0 => data, others => '0');
+
 	rsel <= to_integer(unsigned(addr));
 	
 	process(rclk)

--- a/components/ipbus_slaves/firmware/hdl/ipbus_ported_dpram.vhd
+++ b/components/ipbus_slaves/firmware/hdl/ipbus_ported_dpram.vhd
@@ -69,7 +69,7 @@ architecture rtl of ipbus_ported_dpram is
 	signal sel, rsel: integer range 0 to 2 ** ADDR_WIDTH - 1 := 0;
 	signal wcyc, wcyc_d: std_logic;
 	signal ptr: unsigned(ADDR_WIDTH - 1 downto 0);
-	signal data: std_logic_vector(31 downto 0);
+	signal data: std_logic_vector(DATA_WIDTH - 1 downto 0);
 	signal wea_l, wea_h: std_logic;
 
 begin
@@ -91,14 +91,10 @@ begin
 	
 	sel <= to_integer(ptr);
 	
-	zero_data: if DATA_WIDTH /= 32 generate
-		data(31 downto DATA_WIDTH) <= (others => '0');
-	end generate;
-
 	process(clk)
 	begin
 		if rising_edge(clk) then
-			data(DATA_WIDTH - 1 downto 0) <= ram(sel);
+			data <= ram(sel);
 			if wcyc = '1' and ipb_in.ipb_addr(0) = '1' then
 				ram(sel) := ipb_in.ipb_wdata(DATA_WIDTH - 1 downto 0);
 			end if;
@@ -109,7 +105,7 @@ begin
 	ipb_out.ipb_ack <= ipb_in.ipb_strobe;
 	ipb_out.ipb_err <= '0';
 	ipb_out.ipb_rdata <= (31 - ADDR_WIDTH downto 0 => '0') & std_logic_vector(ptr) when ipb_in.ipb_addr(0)='0'
-		else data;
+		else std_logic_vector(to_unsigned(0, 32 - DATA_WIDTH)) & data;
 
 	rsel <= to_integer(unsigned(addr));
 	


### PR DESCRIPTION
This pull request fixes issue #110 - i.e. it updates the VHDL for the dual-port RAM slaves to remove the 'null range' aggregate assignment statements for which Vivado 2018.3 reports critical warnings

(*N.B.* However, as noted in issue #110, although Vivado 2018.3 reports the 'null range' aggregate assignment as a critical warning, it does not adversely affect the implementation of the dual-port RAM slaves.)