### PR TITLE
Increase transactor interface's limit on packet size

### DIFF
--- a/boards/k800/synth/firmware/hdl/k800_infra.vhd
+++ b/boards/k800/synth/firmware/hdl/k800_infra.vhd
@@ -78,7 +78,7 @@ architecture rtl of k800_infra is
 
   signal pcie_sys_rst_n_i : std_logic;
 
-  signal axi_ms: axi4mm_ms(araddr(15 downto 0), awaddr(15 downto 0), wdata(63 downto 0));
+  signal axi_ms: axi4mm_ms(araddr(63 downto 0), awaddr(63 downto 0), wdata(63 downto 0));
   signal axi_sm: axi4mm_sm(rdata(63 downto 0));
 
   signal ipb_pkt_done : std_logic;

--- a/boards/vcu118/synth/firmware/hdl/vcu118_infra.vhd
+++ b/boards/vcu118/synth/firmware/hdl/vcu118_infra.vhd
@@ -78,7 +78,7 @@ architecture rtl of vcu118_infra is
 
   signal pcie_sys_rst_n_i : std_logic;
 
-  signal axi_ms: axi4mm_ms(araddr(15 downto 0), awaddr(15 downto 0), wdata(63 downto 0));
+  signal axi_ms: axi4mm_ms(araddr(63 downto 0), awaddr(63 downto 0), wdata(63 downto 0));
   signal axi_sm: axi4mm_sm(rdata(63 downto 0));
 
   signal ipb_pkt_done : std_logic;

--- a/components/ipbus_core/firmware/hdl/ipbus_trans_decl.vhd
+++ b/components/ipbus_core/firmware/hdl/ipbus_trans_decl.vhd
@@ -37,7 +37,7 @@ use IEEE.STD_LOGIC_1164.all;
 
 package ipbus_trans_decl is
 
-	constant addr_width: positive := 12;
+	constant addr_width: positive := 16;
 
 	-- Signals from buffer to transactor
 	

--- a/components/ipbus_pcie/firmware/hdl/pcie_xdma_axi_us_if.vhd
+++ b/components/ipbus_pcie/firmware/hdl/pcie_xdma_axi_us_if.vhd
@@ -28,7 +28,7 @@ entity pcie_xdma_axi_us_if is
 
     pcie_user_lnk_up: out std_logic;
 
-    axi_ms : out axi4mm_ms(araddr(15 downto 0), awaddr(15 downto 0), wdata(63 downto 0));
+    axi_ms : out axi4mm_ms(araddr(63 downto 0), awaddr(63 downto 0), wdata(63 downto 0));
     axi_sm : in axi4mm_sm(rdata(63 downto 0));
 
     -- User interrupts
@@ -51,13 +51,10 @@ architecture rtl of pcie_xdma_axi_us_if is
   signal usr_irq_req: std_logic_vector ( C_NUM_USR_IRQ - 1 downto 0 );
   signal usr_irq_ack: std_logic_vector ( C_NUM_USR_IRQ - 1 downto 0 );
 
-  signal xdma_axi_araddr: std_logic_vector(C_AXI_ADDR_WIDTH - 1 DOWNTO 0);
-  signal xdma_axi_awaddr: std_logic_vector(C_AXI_ADDR_WIDTH - 1 DOWNTO 0);
-
   signal msi_vector_width: std_logic_vector ( 2 downto 0 );
   signal msi_enable: std_logic;
 
-  signal axi_ms_i: axi4mm_ms(araddr(15 downto 0), awaddr(15 downto 0), wdata(C_AXI_DATA_WIDTH - 1 downto 0));
+  signal axi_ms_i: axi4mm_ms(araddr(63 downto 0), awaddr(63 downto 0), wdata(C_AXI_DATA_WIDTH - 1 downto 0));
 
   -- components
 
@@ -173,7 +170,7 @@ begin
       m_axi_rlast       => axi_sm.rlast,
       m_axi_rvalid      => axi_sm.rvalid,
       m_axi_awid        => axi_ms_i.awid,
-      m_axi_awaddr      => xdma_axi_awaddr,
+      m_axi_awaddr      => axi_ms_i.awaddr,
       m_axi_awlen       => axi_ms_i.awlen,
       m_axi_awsize      => axi_ms_i.awsize,
       m_axi_awburst     => axi_ms_i.awburst,
@@ -187,7 +184,7 @@ begin
       m_axi_wvalid      => axi_ms_i.wvalid,
       m_axi_bready      => axi_ms_i.bready,
       m_axi_arid        => axi_ms_i.arid,
-      m_axi_araddr      => xdma_axi_araddr,
+      m_axi_araddr      => axi_ms_i.araddr,
       m_axi_arlen       => axi_ms_i.arlen,
       m_axi_arsize      => axi_ms_i.arsize,
       m_axi_arburst     => axi_ms_i.arburst,
@@ -213,8 +210,6 @@ begin
       int_qpll1outclk_out    => open
     );
 
-  axi_ms_i.araddr <= xdma_axi_araddr(axi_ms.araddr'length - 1 downto 0);
-  axi_ms_i.awaddr <= xdma_axi_awaddr(axi_ms.awaddr'length - 1 downto 0);
   axi_ms <= axi_ms_i;
 
   irq_gen: entity work.pcie_int_gen_msix

--- a/components/ipbus_pcie/firmware/hdl/pcie_xdma_axi_usp_if.vhd
+++ b/components/ipbus_pcie/firmware/hdl/pcie_xdma_axi_usp_if.vhd
@@ -28,7 +28,7 @@ entity pcie_xdma_axi_usp_if is
 
     pcie_user_lnk_up: out std_logic;
 
-    axi_ms : out axi4mm_ms(araddr(15 downto 0), awaddr(15 downto 0), wdata(63 downto 0));
+    axi_ms : out axi4mm_ms(araddr(63 downto 0), awaddr(63 downto 0), wdata(63 downto 0));
     axi_sm : in axi4mm_sm(rdata(63 downto 0));
 
     -- User interrupts
@@ -51,13 +51,10 @@ architecture rtl of pcie_xdma_axi_usp_if is
   signal usr_irq_req: std_logic_vector ( C_NUM_USR_IRQ - 1 downto 0 );
   signal usr_irq_ack: std_logic_vector ( C_NUM_USR_IRQ - 1 downto 0 );
 
-  signal xdma_axi_araddr: std_logic_vector(C_AXI_ADDR_WIDTH - 1 DOWNTO 0);
-  signal xdma_axi_awaddr: std_logic_vector(C_AXI_ADDR_WIDTH - 1 DOWNTO 0);
-
   signal msi_vector_width: std_logic_vector ( 2 downto 0 );
   signal msi_enable: std_logic;
 
-  signal axi_ms_i: axi4mm_ms(araddr(15 downto 0), awaddr(15 downto 0), wdata(C_AXI_DATA_WIDTH - 1 downto 0));
+  signal axi_ms_i: axi4mm_ms(araddr(63 downto 0), awaddr(63 downto 0), wdata(C_AXI_DATA_WIDTH - 1 downto 0));
 
   -- components
 
@@ -173,7 +170,7 @@ begin
       m_axi_rlast       => axi_sm.rlast,
       m_axi_rvalid      => axi_sm.rvalid,
       m_axi_awid        => axi_ms_i.awid,
-      m_axi_awaddr      => xdma_axi_awaddr,
+      m_axi_awaddr      => axi_ms_i.awaddr,
       m_axi_awlen       => axi_ms_i.awlen,
       m_axi_awsize      => axi_ms_i.awsize,
       m_axi_awburst     => axi_ms_i.awburst,
@@ -187,7 +184,7 @@ begin
       m_axi_wvalid      => axi_ms_i.wvalid,
       m_axi_bready      => axi_ms_i.bready,
       m_axi_arid        => axi_ms_i.arid,
-      m_axi_araddr      => xdma_axi_araddr,
+      m_axi_araddr      => axi_ms_i.araddr,
       m_axi_arlen       => axi_ms_i.arlen,
       m_axi_arsize      => axi_ms_i.arsize,
       m_axi_arburst     => axi_ms_i.arburst,
@@ -213,8 +210,6 @@ begin
       -- int_qpll1outclk_out    => open  Not available on core v4.0 Ultra+
     );
 
-  axi_ms_i.araddr <= xdma_axi_araddr(axi_ms.araddr'length - 1 downto 0);
-  axi_ms_i.awaddr <= xdma_axi_awaddr(axi_ms.awaddr'length - 1 downto 0);
   axi_ms <= axi_ms_i;
 
   irq_gen: entity work.pcie_int_gen_msix

--- a/components/ipbus_transport_axi/firmware/hdl/ipbus_transport_axi_if.vhd
+++ b/components/ipbus_transport_axi/firmware/hdl/ipbus_transport_axi_if.vhd
@@ -52,7 +52,7 @@ entity ipbus_transport_axi_if is
 		ipb_clk : in std_logic;
 		rst_ipb : in std_logic;
 
-		axi_in  : in axi4mm_ms(araddr(15 downto 0), awaddr(15 downto 0), wdata(63 downto 0));
+		axi_in  : in axi4mm_ms(araddr(63 downto 0), awaddr(63 downto 0), wdata(63 downto 0));
 		axi_out : out axi4mm_sm(rdata(63 downto 0));
 
 		pkt_done : out std_logic;
@@ -71,7 +71,7 @@ architecture rtl of ipbus_transport_axi_if is
 			s_axi_aclk : IN STD_LOGIC;
 			s_axi_aresetn : IN STD_LOGIC;
 			s_axi_awid : IN STD_LOGIC_VECTOR(3 DOWNTO 0);
-			s_axi_awaddr : IN STD_LOGIC_VECTOR(15 DOWNTO 0);
+			s_axi_awaddr : IN STD_LOGIC_VECTOR(BUFWIDTH+ADDRWIDTH+2 DOWNTO 0);
 			s_axi_awlen : IN STD_LOGIC_VECTOR(7 DOWNTO 0);
 			s_axi_awsize : IN STD_LOGIC_VECTOR(2 DOWNTO 0);
 			s_axi_awburst : IN STD_LOGIC_VECTOR(1 DOWNTO 0);
@@ -90,7 +90,7 @@ architecture rtl of ipbus_transport_axi_if is
 			s_axi_bvalid : OUT STD_LOGIC;
 			s_axi_bready : IN STD_LOGIC;
 			s_axi_arid : IN STD_LOGIC_VECTOR(3 DOWNTO 0);
-			s_axi_araddr : IN STD_LOGIC_VECTOR(15 DOWNTO 0);
+			s_axi_araddr : IN STD_LOGIC_VECTOR(BUFWIDTH+ADDRWIDTH+2 DOWNTO 0);
 			s_axi_arlen : IN STD_LOGIC_VECTOR(7 DOWNTO 0);
 			s_axi_arsize : IN STD_LOGIC_VECTOR(2 DOWNTO 0);
 			s_axi_arburst : IN STD_LOGIC_VECTOR(1 DOWNTO 0);
@@ -109,22 +109,20 @@ architecture rtl of ipbus_transport_axi_if is
 			bram_clk_a : OUT STD_LOGIC;
 			bram_en_a : OUT STD_LOGIC;
 			bram_we_a : OUT STD_LOGIC_VECTOR(7 DOWNTO 0);
-			bram_addr_a : OUT STD_LOGIC_VECTOR(15 DOWNTO 0);
+			bram_addr_a : OUT STD_LOGIC_VECTOR(BUFWIDTH+ADDRWIDTH+2 DOWNTO 0);
 			bram_wrdata_a : OUT STD_LOGIC_VECTOR(63 DOWNTO 0);
 			bram_rddata_a : IN STD_LOGIC_VECTOR(63 DOWNTO 0);
 			bram_rst_b : OUT STD_LOGIC;
 			bram_clk_b : OUT STD_LOGIC;
 			bram_en_b : OUT STD_LOGIC;
 			bram_we_b : OUT STD_LOGIC_VECTOR(7 DOWNTO 0);
-			bram_addr_b : OUT STD_LOGIC_VECTOR(15 DOWNTO 0);
+			bram_addr_b : OUT STD_LOGIC_VECTOR(BUFWIDTH+ADDRWIDTH+2 DOWNTO 0);
 			bram_wrdata_b : OUT STD_LOGIC_VECTOR(63 DOWNTO 0);
 			bram_rddata_b : IN STD_LOGIC_VECTOR(63 DOWNTO 0)
 		);
 	END COMPONENT;
 
-	constant bram_addr_zero : std_logic_vector(15 downto 0) := (Others => '0');
-
-	signal bram_addr_a, bram_addr_b : std_logic_vector(15 downto 0);
+	signal bram_addr_a, bram_addr_b : std_logic_vector(BUFWIDTH+ADDRWIDTH+2 downto 0);
 	signal ram_wr_en, ram_we, ram_rd_en : std_logic;
 	signal ram_wr_we : std_logic_vector(7 downto 0);
 	signal ram_wr_data, ram_rd_data : std_logic_vector(63 downto 0);
@@ -138,7 +136,7 @@ begin
 
 			s_axi_aresetn    => axi_in.aresetn,
 			s_axi_awid       => axi_in.awid,
-			s_axi_awaddr     => axi_in.awaddr,
+			s_axi_awaddr     => axi_in.awaddr(BUFWIDTH+ADDRWIDTH+2 downto 0),
 			s_axi_awlen      => axi_in.awlen,
 			s_axi_awsize     => axi_in.awsize,
 			s_axi_awburst    => axi_in.awburst,
@@ -159,7 +157,7 @@ begin
 			s_axi_bvalid     => axi_out.bvalid,
 			s_axi_bready     => axi_in.bready,
 			s_axi_arid       => axi_in.arid,
-			s_axi_araddr     => axi_in.araddr,
+			s_axi_araddr     => axi_in.araddr(BUFWIDTH+ADDRWIDTH+2 downto 0),
 			s_axi_arlen      => axi_in.arlen,
 			s_axi_arsize     => axi_in.arsize,
 			s_axi_arburst    => axi_in.arburst,

--- a/components/ipbus_transport_udp/firmware/hdl/udp_if_flat.vhd
+++ b/components/ipbus_transport_udp/firmware/hdl/udp_if_flat.vhd
@@ -69,8 +69,8 @@ ENTITY UDP_if IS
 		mac_tx_ready: IN std_logic;
 		pkt_done_read: IN std_logic;
 		pkt_done_write: IN std_logic;
-		raddr: IN std_logic_vector(11 DOWNTO 0);
-		waddr: IN std_logic_vector(11 DOWNTO 0);
+		raddr: IN std_logic_vector(15 DOWNTO 0);
+		waddr: IN std_logic_vector(15 DOWNTO 0);
 		wdata: IN std_logic_vector(31 DOWNTO 0);
 		we: IN std_logic;
 		busy: OUT std_logic;


### PR DESCRIPTION
This pull request addresses issue #117 - i.e:
 * Increases `ipbus_trans_decl.addr_width` to 16 (was 12)
 * Increases address width in the AXI transport interface's BRAM controller