### PR TITLE
Fix MMCM clock period typo in clocks modules

### DIFF
--- a/components/ipbus_util/firmware/hdl/clocks/clocks_7s_extphy.vhd
+++ b/components/ipbus_util/firmware/hdl/clocks/clocks_7s_extphy.vhd
@@ -114,7 +114,7 @@ begin
 
 	mmcm: MMCME2_BASE
 		generic map(
-			clkin1_period => CLK_VCO_FREQ / CLK_FR_FREQ,
+			clkin1_period => 1000.0 / CLK_FR_FREQ,
 			clkfbout_mult_f => CLK_VCO_FREQ / CLK_FR_FREQ,
 			clkout1_divide => integer(CLK_VCO_FREQ / 125.00),
 			clkout2_divide => integer(CLK_VCO_FREQ / 125.00),

--- a/components/ipbus_util/firmware/hdl/clocks/clocks_7s_extphy_se.vhd
+++ b/components/ipbus_util/firmware/hdl/clocks/clocks_7s_extphy_se.vhd
@@ -119,7 +119,7 @@ begin
 
 	mmcm: MMCME2_BASE
 		generic map(
-			clkin1_period => CLK_VCO_FREQ / CLK_FR_FREQ,
+			clkin1_period => 1000.0 / CLK_FR_FREQ,
 			clkfbout_mult_f => CLK_VCO_FREQ / CLK_FR_FREQ,
 			clkout1_divide => integer(CLK_VCO_FREQ / 125.00), -- 125 MHz clock
 			clkout2_divide => integer(CLK_VCO_FREQ / 125.00), -- 125 MHz clock, 90 deg phase

--- a/components/ipbus_util/firmware/hdl/clocks/clocks_7s_serdes.vhd
+++ b/components/ipbus_util/firmware/hdl/clocks/clocks_7s_serdes.vhd
@@ -98,7 +98,7 @@ begin
 	
 	mmcm: MMCME2_BASE
 		generic map(
-			clkin1_period => CLK_VCO_FREQ / CLK_FR_FREQ,
+			clkin1_period => 1000.0 / CLK_FR_FREQ,
 			clkfbout_mult_f => CLK_VCO_FREQ / CLK_FR_FREQ,
 			clkout1_divide => integer(CLK_VCO_FREQ / 31.25),
 			clkout2_divide => integer(CLK_VCO_FREQ / CLK_AUX_FREQ),

--- a/components/ipbus_util/firmware/hdl/clocks/clocks_us_serdes.vhd
+++ b/components/ipbus_util/firmware/hdl/clocks/clocks_us_serdes.vhd
@@ -98,7 +98,7 @@ begin
 	
 	mmcm: MMCME3_BASE
 		generic map(
-			clkin1_period => CLK_VCO_FREQ / CLK_FR_FREQ,
+			clkin1_period => 1000.0 / CLK_FR_FREQ,
 			clkfbout_mult_f => CLK_VCO_FREQ / CLK_FR_FREQ,
 			clkout1_divide => integer(CLK_VCO_FREQ / 31.25),
 			clkout2_divide => integer(CLK_VCO_FREQ / CLK_AUX_FREQ),

--- a/components/ipbus_util/firmware/hdl/clocks/clocks_us_serdes.vhd
+++ b/components/ipbus_util/firmware/hdl/clocks/clocks_us_serdes.vhd
@@ -173,9 +173,9 @@ begin
 	
 	rsto_fr <= rst;
 	
-	process(clk_aux_i)
+	process(clk_aux_b)
 	begin
-		if rising_edge(clk_aux_i) then
+		if rising_edge(clk_aux_b) then
 			rst_aux <= rst;
 		end if;
 	end process;

--- a/components/ipbus_util/firmware/hdl/clocks/clocks_usp_serdes.vhd
+++ b/components/ipbus_util/firmware/hdl/clocks/clocks_usp_serdes.vhd
@@ -176,9 +176,9 @@ begin
 	
 	rsto_fr <= rst;
 		
-	process(clk_aux_i)
+	process(clk_aux_b)
 	begin
-		if rising_edge(clk_aux_i) then
+		if rising_edge(clk_aux_b) then
 			rst_aux <= rst;
 		end if;
 	end process;

--- a/components/ipbus_util/firmware/hdl/clocks/clocks_usp_serdes.vhd
+++ b/components/ipbus_util/firmware/hdl/clocks/clocks_usp_serdes.vhd
@@ -101,7 +101,7 @@ begin
 	
 	mmcm: MMCME4_BASE
 		generic map(
-			clkin1_period => CLK_VCO_FREQ / CLK_FR_FREQ,
+			clkin1_period => 1000.0 / CLK_FR_FREQ,
 			clkfbout_mult_f => CLK_VCO_FREQ / CLK_FR_FREQ,
 			clkout1_divide => integer(CLK_VCO_FREQ / 31.25),
 			clkout2_divide => integer(CLK_VCO_FREQ / CLK_AUX_FREQ),


### PR DESCRIPTION
This pull request resolves issues #127 and #128 - i.e. it:
 * Updates the clocks modules to set the `clkin1_period` generic to `1000.0 / CLK_FR_FREQ`
 * Updates the process generating `rsto_aux` in `clocks_us_serdes.vhd` and `clocks_usp_serdes.vhd` to use the post-buffer signal for the aux clock.