### PR TITLE
Fix LED mask in example design address tables

### DIFF
--- a/components/ipbus_util/addr_table/ipbus_example.xml
+++ b/components/ipbus_util/addr_table/ipbus_example.xml
@@ -3,7 +3,7 @@
         <node id="ctrl" address="0x0">
             <node id="rst" mask="0x1"/>
             <node id="nuke" mask="0x2"/>
-            <node id="led" mask="0x3"/>
+            <node id="led" mask="0x4"/>
         </node>
         <node id="stat" address="0x1"/>
     </node>


### PR DESCRIPTION
As described in title; fixed #130 