### PR TITLE
Fixing dependency file for ipbus_transport_axi to include the ipbus_e…

### DIFF
--- a/components/ipbus_transport_axi/firmware/cfg/ipbus_transport_axi.dep
+++ b/components/ipbus_transport_axi/firmware/cfg/ipbus_transport_axi.dep
@@ -36,3 +36,5 @@ src ipbus_axi_decl.vhd
 ?toolset=="Vivado"? src ../cgn/axi_bram_ctrl_0.xci
 
 include -c components/ipbus_core
+# The following is internally used by the ipbus_transport_ram_if_simtb.
+include -c components/ipbus_util ipbus_example.dep


### PR DESCRIPTION
…xample that is used internally by ipbus_transport_ram_if_simtb.