### PR TITLE
Create depfile for ipbus_ctrl.vhd

### DIFF
--- a/boards/enclustra_ax3_pm3/synth/firmware/cfg/enclustra_ax3_pm3_infra.dep
+++ b/boards/enclustra_ax3_pm3/synth/firmware/cfg/enclustra_ax3_pm3_infra.dep
@@ -26,7 +26,6 @@
 
 src enclustra_ax3_pm3_infra.vhd
 src -c components/ipbus_util clocks/clocks_7s_extphy_se.vhd ipbus_clock_div.vhd led_stretcher.vhd
-src -c components/ipbus_util masters/ipbus_ctrl.vhd
-include -c components/ipbus_transport_udp
+include -c components/ipbus_util ipbus_ctrl.dep
 include -c components/ipbus_eth artix_rgmii.dep
 src -c components/ipbus_core ipbus_fabric_sel.vhd ipbus_package.vhd

--- a/boards/kc705/basex/synth/firmware/cfg/kc705_basex_infra.dep
+++ b/boards/kc705/basex/synth/firmware/cfg/kc705_basex_infra.dep
@@ -26,7 +26,6 @@
 
 src kc705_basex_infra.vhd
 src -c components/ipbus_util clocks/clocks_7s_serdes.vhd ipbus_clock_div.vhd led_stretcher.vhd
-src -c components/ipbus_util masters/ipbus_ctrl.vhd
-include -c components/ipbus_transport_udp
+include -c components/ipbus_util ipbus_ctrl.dep
 include -c components/ipbus_eth kc705_basex.dep
 src -c components/ipbus_core ipbus_fabric_sel.vhd ipbus_package.vhd

--- a/boards/kc705/gmii/synth/firmware/cfg/kc705_gmii_infra.dep
+++ b/boards/kc705/gmii/synth/firmware/cfg/kc705_gmii_infra.dep
@@ -26,7 +26,6 @@
 
 src kc705_gmii_infra.vhd
 src -c components/ipbus_util clocks/clocks_7s_extphy.vhd ipbus_clock_div.vhd led_stretcher.vhd
-src -c components/ipbus_util masters/ipbus_ctrl.vhd
-include -c components/ipbus_transport_udp
+include -c components/ipbus_util ipbus_ctrl.dep
 include -c components/ipbus_eth kc705_gmii.dep
 src -c components/ipbus_core ipbus_fabric_sel.vhd ipbus_package.vhd

--- a/boards/kcu105/basex/synth/firmware/cfg/kcu105_basex_infra.dep
+++ b/boards/kcu105/basex/synth/firmware/cfg/kcu105_basex_infra.dep
@@ -26,7 +26,6 @@
 
 src kcu105_basex_infra.vhd
 src -c components/ipbus_util clocks/clocks_us_serdes.vhd ipbus_clock_div.vhd led_stretcher.vhd
-src -c components/ipbus_util masters/ipbus_ctrl.vhd
-include -c components/ipbus_transport_udp
+include -c components/ipbus_util ipbus_ctrl.dep
 include -c components/ipbus_eth kcu105_basex.dep
 src -c components/ipbus_core ipbus_fabric_sel.vhd ipbus_package.vhd

--- a/boards/sim/firmware/cfg/sim_eth_infra.dep
+++ b/boards/sim/firmware/cfg/sim_eth_infra.dep
@@ -27,6 +27,5 @@
 src sim_eth_infra.vhd
 src -c components/ipbus_util ../sim_hdl/clock_sim.vhd
 include -c components/modelsim_fli/eth
-src -c components/ipbus_util masters/ipbus_ctrl.vhd
-include -c components/ipbus_transport_udp
+include -c components/ipbus_util ipbus_ctrl.dep
 include -c components/ipbus_core

--- a/boards/vcu118/sgmii/synth/firmware/cfg/vcu118_infra_sgmii.dep
+++ b/boards/vcu118/sgmii/synth/firmware/cfg/vcu118_infra_sgmii.dep
@@ -33,7 +33,6 @@
 
 src vcu118_infra_sgmii.vhd
 src -c components/ipbus_util clocks/clocks_usp_serdes.vhd ipbus_clock_div.vhd led_stretcher.vhd
-src -c components/ipbus_util masters/ipbus_ctrl.vhd
-include -c components/ipbus_transport_udp
+include -c components/ipbus_util ipbus_ctrl.dep
 include eth_sgmii_lvds_vcu118.dep
 src -c components/ipbus_core ipbus_fabric_sel.vhd ipbus_package.vhd

--- a/boards/zcu102/basex/synth/firmware/cfg/zcu102_basex_infra.dep
+++ b/boards/zcu102/basex/synth/firmware/cfg/zcu102_basex_infra.dep
@@ -26,7 +26,6 @@
 
 src zcu102_basex_infra.vhd
 src -c components/ipbus_util clocks/clocks_us_serdes.vhd ipbus_clock_div.vhd led_stretcher.vhd
-src -c components/ipbus_util masters/ipbus_ctrl.vhd
-include -c components/ipbus_transport_udp
+include -c components/ipbus_util ipbus_ctrl.dep
 include -c components/ipbus_eth zcu102_basex.dep
 src -c components/ipbus_core ipbus_fabric_sel.vhd ipbus_package.vhd

--- a/components/ipbus_core/firmware/cfg/ipbus_core.dep
+++ b/components/ipbus_core/firmware/cfg/ipbus_core.dep
@@ -26,7 +26,6 @@
 
 # Dependencies for ipbus_core
 
-src trans_arb.vhd
 src transactor.vhd
 src transactor_if.vhd
 src transactor_sm.vhd

--- a/components/ipbus_util/firmware/cfg/ipbus_ctrl.dep
+++ b/components/ipbus_util/firmware/cfg/ipbus_ctrl.dep
@@ -24,8 +24,8 @@
 #-------------------------------------------------------------------------------
 
 
-src pc053a_infra.vhd
-src -c components/ipbus_util clocks/clocks_7s_serdes.vhd ipbus_clock_div.vhd led_stretcher.vhd
-include -c components/ipbus_util ipbus_ctrl.dep
-include -c components/ipbus_eth artix_basex.dep
-src -c components/ipbus_core ipbus_fabric_sel.vhd ipbus_package.vhd
+src masters/ipbus_ctrl.vhd
+src -c components/ipbus_core trans_arb.vhd
+
+include -c components/ipbus_transport_udp
+include -c components/ipbus_core


### PR DESCRIPTION
This branch addresses the suggestion from issue #140, by:
 * Removing `trans_arb.vhd` from the `ipbus_core` depfile (since it's not used by several designs that only use one 'transport interface' designs - e.g. the PCIe designs)
 * Adding a new depfile, `ipbus_ctrl.dep` under `components/ipbus_util` that references `ipbus_ctrl.vhd` and all its dependencies