### PR TITLE
Bumping DRP address width to 16 bits

### DIFF
--- a/components/ipbus_slaves/firmware/hdl/drp_decl.vhd
+++ b/components/ipbus_slaves/firmware/hdl/drp_decl.vhd
@@ -34,26 +34,26 @@ library IEEE;
 use IEEE.STD_LOGIC_1164.all;
 
 package drp_decl is
-  
+
 -- The signals going from master to slaves
 	type drp_wbus is
-  		record
-  			addr: std_logic_vector(15 downto 0);
-      	data: std_logic_vector(15 downto 0);
-      	en: std_logic;
-      	we: std_logic;
-    	end record;
+		record
+			addr: std_logic_vector(15 downto 0);
+			data: std_logic_vector(15 downto 0);
+			en: std_logic;
+			we: std_logic;
+		end record;
 
 	type drp_wbus_array is array(natural range <>) of drp_wbus;
 	
 	constant DRP_WBUS_NULL: drp_wbus := ((others => '0'), (others => '0'), '0', '0');
-	 
+	
 -- The signals going from slaves to master	 
 	type drp_rbus is
-    record
+		record
 			data: std_logic_vector(15 downto 0);
 			rdy: std_logic;
-    end record;
+		end record;
 
 	type drp_rbus_array is array(natural range <>) of drp_rbus;
 	

--- a/components/ipbus_slaves/firmware/hdl/drp_decl.vhd
+++ b/components/ipbus_slaves/firmware/hdl/drp_decl.vhd
@@ -38,7 +38,7 @@ package drp_decl is
 -- The signals going from master to slaves
 	type drp_wbus is
   		record
-  			addr: std_logic_vector(8 downto 0);
+  			addr: std_logic_vector(15 downto 0);
       	data: std_logic_vector(15 downto 0);
       	en: std_logic;
       	we: std_logic;

--- a/components/ipbus_slaves/firmware/hdl/ipbus_drp_bridge.vhd
+++ b/components/ipbus_slaves/firmware/hdl/ipbus_drp_bridge.vhd
@@ -65,7 +65,7 @@ begin
 	stb <= ipb_in.ipb_strobe and not busy;
 	cyc <= stb and not stb_d;
 
-	drp_out.addr <= ipb_in.ipb_addr(8 downto 0);
+	drp_out.addr <= ipb_in.ipb_addr(15 downto 0);
 	drp_out.en <= cyc;
 	drp_out.data <= ipb_in.ipb_wdata(15 downto 0);
 	drp_out.we <= cyc and ipb_in.ipb_write;

--- a/components/ipbus_slaves/firmware/hdl/ipbus_reg_types.vhd
+++ b/components/ipbus_slaves/firmware/hdl/ipbus_reg_types.vhd
@@ -51,13 +51,13 @@ package body ipbus_reg_types is
 	end function calc_width;
 
 	function integer_max(left, right: integer) return integer is
-  begin
-    if left > right then
-    	return left;
-    else
-    	return right;
-    end if;
-  end function integer_max;
+	begin
+		if left > right then
+			return left;
+		else
+			return right;
+		end if;
+	end function integer_max;
 	
 end package body ipbus_reg_types;
 


### PR DESCRIPTION
Bumping DRP address width to 16 bits, in order to support UltraScale+ GTH/GTY.

This should settle issue #150.

Please note: as far as I can see, this change is _not_ exercised by any of the tests. This could change after adding the sysmon examples from pull request #145.