### PR TITLE
This fixes IPbus issue #162

### DIFF
--- a/components/opencores_i2c/addr_table/opencores_i2c.xml
+++ b/components/opencores_i2c/addr_table/opencores_i2c.xml
@@ -1,4 +1,4 @@
-<node description="I2C master controller" fwinfo="endpoint;width=3">
+<node id="i2c_master" description="I2C master controller" fwinfo="endpoint;width=3">
 	<node id="ps_lo" address="0x0" description="Prescale low byte"/>
 	<node id="ps_hi" address="0x1" description="Prescale low byte"/>
 	<node id="ctrl" address="0x2" description="Control"/>


### PR DESCRIPTION
Simply adding an 'id' attribute to the top-level node of opencores_i2c.xml.