### PR TITLE
Address tables: Remove id attribute from root nodes

### DIFF
--- a/ci/sim.yml
+++ b/ci/sim.yml
@@ -1,7 +1,7 @@
 
 run_sim_udp:vivado2018.3:modelsim10.6c:
   extends: .template_base
-  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-fw-dev-cc7:2019-04-30__ipbb0.5.0
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-fw-dev-cc7:2020-03-15__ipbb0.5.2_uhal2.7.2
   tags:
     - docker
     - docker-cap-net-admin
@@ -24,7 +24,7 @@ run_sim_udp:vivado2018.3:modelsim10.6c:
 
 run_sim:vivado2018.3:modelsim10.6c:
   extends: .template_base
-  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-fw-dev-cc7:2019-04-30__ipbb0.5.0
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-fw-dev-cc7:2020-03-15__ipbb0.5.2_uhal2.7.2
   tags:
     - docker
     - docker-cap-net-admin
@@ -48,7 +48,7 @@ run_sim:vivado2018.3:modelsim10.6c:
 
 run_ram_slaves_testbench_sim:vivado2018.3:modelsim10.6c:
   extends: .template_base
-  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-fw-dev-cc7:2019-04-30__ipbb0.5.0
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-fw-dev-cc7:2020-03-15__ipbb0.5.2_uhal2.7.2
   tags:
     - docker
     - docker-cap-net-admin
@@ -77,7 +77,7 @@ run_ram_slaves_testbench_sim:vivado2018.3:modelsim10.6c:
 
 run_ctr_slaves_testbench_sim:vivado2018.3:modelsim10.6c:
   extends: .template_base
-  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-fw-dev-cc7:2019-04-30__ipbb0.5.0
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-fw-dev-cc7:2020-03-15__ipbb0.5.2_uhal2.7.2
   tags:
     - docker
     - xilinx-tools

--- a/ci/templates.yml
+++ b/ci/templates.yml
@@ -1,6 +1,6 @@
 
 .template_base:
-  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-fw-dev-cc7:2019-09-17__ipbb0.5.2
+  image: ${IPBUS_DOCKER_REGISTRY}/ipbus-fw-dev-cc7:2020-03-15__ipbb0.5.2_uhal2.7.2
   before_script:
     - source /software/Xilinx/Vivado/${VIVADO_VERSION}/settings64.sh
 

--- a/components/ipbus_slaves/addr_table/ipbus_axi4lite_master.xml
+++ b/components/ipbus_slaves/addr_table/ipbus_axi4lite_master.xml
@@ -1,4 +1,6 @@
-<node id="ipbus_axi4lite_master" fwinfo="endpoint;width=3">
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<node fwinfo="endpoint;width=3">
 
   <node id="ctrl" address="0x00000000" permission="rw">
       <!-- Access mode: 0 = read, 1 = write. -->

--- a/components/ipbus_slaves/addr_table/ipbus_freq_ctr.xml
+++ b/components/ipbus_slaves/addr_table/ipbus_freq_ctr.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
 <node description="Frequency counter" fwinfo="endpoint;width=1">
 	<node id="ctrl" address="0x0">
 		<node id="chan_sel" mask="0xf"/>

--- a/components/ipbus_util/addr_table/ipbus_device_dna_us_usp.xml
+++ b/components/ipbus_util/addr_table/ipbus_device_dna_us_usp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 
-<node id="ipbus_device_dna" fwinfo="endpoint; width=2">
+<node fwinfo="endpoint; width=2">
 
   <!-- The Xilinx device DNA (for UltraScale and UltraScale+ devices)
        is a 96-bit value. -->

--- a/components/ipbus_util/addr_table/ipbus_example.xml
+++ b/components/ipbus_util/addr_table/ipbus_example.xml
@@ -1,4 +1,6 @@
-<node id="TOP">
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<node>
     <node id="csr" address="0x0" description="ctrl/stat register" fwinfo="endpoint;width=1">
         <node id="ctrl" address="0x0">
             <node id="rst" mask="0x1"/>

--- a/components/ipbus_util/addr_table/ipbus_example_xilinx_usp.xml
+++ b/components/ipbus_util/addr_table/ipbus_example_xilinx_usp.xml
@@ -1,4 +1,6 @@
-<node id="TOP">
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<node>
 
   <node id="device_dna"
         module="file://ipbus_device_dna_us_usp.xml"

--- a/components/ipbus_util/addr_table/ipbus_example_xilinx_x7.xml
+++ b/components/ipbus_util/addr_table/ipbus_example_xilinx_x7.xml
@@ -1,4 +1,6 @@
-<node id="TOP">
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<node>
 
   <!-- NOTE: Remember that the lower nine bits are sent straight to
        the sysmon. So keep this at an appropriate offset from 0x0. -->

--- a/components/ipbus_util/addr_table/ipbus_icap.xml
+++ b/components/ipbus_util/addr_table/ipbus_icap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 
-<node id="ipbus_icap" fwinfo="endpoint; width=3">
+<node fwinfo="endpoint; width=3">
 
   <node id="access_mode" address="0x00000000" mask="0x00000003" />
   <node id="access_strobe" address="0x00000000" mask="0x00000004" />

--- a/components/ipbus_util/addr_table/ipbus_iprog.xml
+++ b/components/ipbus_util/addr_table/ipbus_iprog.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 
-<node id="ipbus_iprog" fwinfo="endpoint; width=1">
+<node fwinfo="endpoint; width=1">
 
   <node id="reconfigure" address="0x00000000" mask="0x00000001" />
   <node id="address" address="0x00000001" mask="0xffffffff" />

--- a/components/ipbus_util/addr_table/ipbus_sysmon_us_ext_ref.xml
+++ b/components/ipbus_util/addr_table/ipbus_sysmon_us_ext_ref.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 
-<node id="sysmon_us_ext_ref" fwinfo="endpoint; width=8">
+<node fwinfo="endpoint; width=8">
 
   <!-- NOTE: Since the lower nine bits of the address are passed
        straigh to the DRP side of the sysmon, one should not

--- a/components/ipbus_util/addr_table/ipbus_sysmon_us_int_ref.xml
+++ b/components/ipbus_util/addr_table/ipbus_sysmon_us_int_ref.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 
-<node id="sysmon_us_int_ref" fwinfo="endpoint; width=8">
+<node fwinfo="endpoint; width=8">
 
   <!-- NOTE: Since the lower nine bits of the address are passed
        straigh to the DRP side of the sysmon, one should not

--- a/components/ipbus_util/addr_table/ipbus_sysmon_usp_ext_ref.xml
+++ b/components/ipbus_util/addr_table/ipbus_sysmon_usp_ext_ref.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 
-<node id="sysmon_usp_ext_ref" fwinfo="endpoint; width=8">
+<node fwinfo="endpoint; width=8">
 
   <!-- NOTE: Since the lower nine bits of the address are passed
        straigh to the DRP side of the sysmon, one should not

--- a/components/ipbus_util/addr_table/ipbus_sysmon_usp_int_ref.xml
+++ b/components/ipbus_util/addr_table/ipbus_sysmon_usp_int_ref.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 
-<node id="sysmon_usp_int_ref" fwinfo="endpoint; width=8">
+<node fwinfo="endpoint; width=8">
 
   <!-- NOTE: Since the lower nine bits of the address are passed
        straigh to the DRP side of the sysmon, one should not

--- a/components/ipbus_util/addr_table/ipbus_sysmon_x7.xml
+++ b/components/ipbus_util/addr_table/ipbus_sysmon_x7.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 
-<node id="sysmon_x7" fwinfo="endpoint; width=8">
+<node fwinfo="endpoint; width=8">
 
   <!-- NOTE: Since the lower nine bits of the address are passed
        straigh to the DRP side of the sysmon, one should not

--- a/components/ipbus_util/addr_table/trans_buffer_test.xml
+++ b/components/ipbus_util/addr_table/trans_buffer_test.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
 <node description="Transactor interface test block" size="0x2" tags="slave">
 	<node id="w" address="0x0"/>
 	<node id="r" address="0x1"/>

--- a/components/opencores_i2c/addr_table/opencores_i2c.xml
+++ b/components/opencores_i2c/addr_table/opencores_i2c.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
 <node description="I2C master controller" fwinfo="endpoint;width=3">
 	<node id="ps_lo" address="0x0" description="Prescale low byte"/>
 	<node id="ps_hi" address="0x1" description="Prescale low byte"/>

--- a/components/opencores_spi/addr_table/opencores_spi.xml
+++ b/components/opencores_spi/addr_table/opencores_spi.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
 <node description="SPI master controller" fwinfo="endpoint;width=3">
 	<node id="d0" address="0x0" description="Data reg 0"/>
 	<node id="d1" address="0x1" description="Data reg 1"/>

--- a/tests/ctr_slaves/addr_table/ctr_slaves_tester.xml
+++ b/tests/ctr_slaves/addr_table/ctr_slaves_tester.xml
@@ -1,4 +1,6 @@
-<node id="TOP">
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<node>
 	<node id="csr" address="0x0" description="control/status registers" fwinfo="endpoint;width=1">
 		<node id="ctrl" address="0x0">
 			<node id="rst" mask="0x1"/>

--- a/tests/ram_slaves/addr_table/ram_slaves_tester.xml
+++ b/tests/ram_slaves/addr_table/ram_slaves_tester.xml
@@ -1,4 +1,6 @@
-<node id="TOP">
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<node>
     <node id="csr" address="0x0" description="ctrl/stat register" fwinfo="endpoint;width=1">
         <node id="ctrl" address="0x0">
             <node id="rst" mask="0x1"/>


### PR DESCRIPTION
This pull request:
 * Updates the CI config to use docker containers with uHAL v2.7.2 (which applies stricter checks when parsing address tables)
 * Removes the `id` attribute from the root node of all address tables in the repo (since the `id` attribute is never used for root nodes).