### PR TITLE
axi bus implementation on top address space of ipbus

### DIFF
--- a/components/ipbus_transport_axi/firmware/bd/axi_ic/axi_ic.bd
+++ b/components/ipbus_transport_axi/firmware/bd/axi_ic/axi_ic.bd
@@ -1,0 +1,821 @@
+{
+  "design": {
+    "design_info": {
+      "boundary_crc": "0xC029478B12A60D7C",
+      "device": "xcvu7p-flvb2104-1-e",
+      "name": "axi_ic",
+      "synth_flow_mode": "Hierarchical",
+      "tool_version": "2019.2",
+      "validated": "true"
+    },
+    "design_tree": {
+      "axi_ic_0": {
+        "xbar": "",
+        "s00_couplers": {},
+        "m00_couplers": {},
+        "m01_couplers": {}
+      }
+    },
+    "interface_ports": {
+      "pcie_axi": {
+        "mode": "Slave",
+        "vlnv": "xilinx.com:interface:aximm_rtl:1.0",
+        "parameters": {
+          "DATA_WIDTH": {
+            "value": "64"
+          },
+          "PROTOCOL": {
+            "value": "AXI4"
+          },
+          "FREQ_HZ": {
+            "value": "125000000"
+          },
+          "ID_WIDTH": {
+            "value": "0"
+          },
+          "ADDR_WIDTH": {
+            "value": "64"
+          },
+          "AWUSER_WIDTH": {
+            "value": "0"
+          },
+          "ARUSER_WIDTH": {
+            "value": "0"
+          },
+          "WUSER_WIDTH": {
+            "value": "0"
+          },
+          "RUSER_WIDTH": {
+            "value": "0"
+          },
+          "BUSER_WIDTH": {
+            "value": "0"
+          },
+          "READ_WRITE_MODE": {
+            "value": "READ_WRITE"
+          },
+          "HAS_BURST": {
+            "value": "1"
+          },
+          "HAS_LOCK": {
+            "value": "1"
+          },
+          "HAS_PROT": {
+            "value": "1"
+          },
+          "HAS_CACHE": {
+            "value": "1"
+          },
+          "HAS_QOS": {
+            "value": "1"
+          },
+          "HAS_REGION": {
+            "value": "0"
+          },
+          "HAS_WSTRB": {
+            "value": "1"
+          },
+          "HAS_BRESP": {
+            "value": "1"
+          },
+          "HAS_RRESP": {
+            "value": "1"
+          },
+          "SUPPORTS_NARROW_BURST": {
+            "value": "1"
+          },
+          "NUM_READ_OUTSTANDING": {
+            "value": "2"
+          },
+          "NUM_WRITE_OUTSTANDING": {
+            "value": "2"
+          },
+          "MAX_BURST_LENGTH": {
+            "value": "256"
+          },
+          "PHASE": {
+            "value": "0.000",
+            "value_src": "default"
+          },
+          "CLK_DOMAIN": {
+            "value": "axi_ic_ACLK_0",
+            "value_src": "default"
+          },
+          "NUM_READ_THREADS": {
+            "value": "1"
+          },
+          "NUM_WRITE_THREADS": {
+            "value": "1"
+          },
+          "RUSER_BITS_PER_BYTE": {
+            "value": "0"
+          },
+          "WUSER_BITS_PER_BYTE": {
+            "value": "0"
+          },
+          "INSERT_VIP": {
+            "value": "0",
+            "value_src": "default"
+          }
+        }
+      },
+      "ipb_axi": {
+        "mode": "Master",
+        "vlnv": "xilinx.com:interface:aximm_rtl:1.0",
+        "parameters": {
+          "DATA_WIDTH": {
+            "value": "64"
+          },
+          "PROTOCOL": {
+            "value": "AXI4"
+          },
+          "FREQ_HZ": {
+            "value": "125000000"
+          },
+          "ID_WIDTH": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "ADDR_WIDTH": {
+            "value": "64"
+          },
+          "AWUSER_WIDTH": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "ARUSER_WIDTH": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "WUSER_WIDTH": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "RUSER_WIDTH": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "BUSER_WIDTH": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "READ_WRITE_MODE": {
+            "value": "READ_WRITE",
+            "value_src": "default"
+          },
+          "HAS_BURST": {
+            "value": "1",
+            "value_src": "default"
+          },
+          "HAS_LOCK": {
+            "value": "1",
+            "value_src": "default"
+          },
+          "HAS_PROT": {
+            "value": "1",
+            "value_src": "default"
+          },
+          "HAS_CACHE": {
+            "value": "1",
+            "value_src": "default"
+          },
+          "HAS_QOS": {
+            "value": "0"
+          },
+          "HAS_REGION": {
+            "value": "0"
+          },
+          "HAS_WSTRB": {
+            "value": "1",
+            "value_src": "default"
+          },
+          "HAS_BRESP": {
+            "value": "1",
+            "value_src": "default"
+          },
+          "HAS_RRESP": {
+            "value": "1",
+            "value_src": "default"
+          },
+          "SUPPORTS_NARROW_BURST": {
+            "value": "1",
+            "value_src": "default"
+          },
+          "NUM_READ_OUTSTANDING": {
+            "value": "2"
+          },
+          "NUM_WRITE_OUTSTANDING": {
+            "value": "2"
+          },
+          "MAX_BURST_LENGTH": {
+            "value": "256",
+            "value_src": "default"
+          },
+          "PHASE": {
+            "value": "0.000",
+            "value_src": "default"
+          },
+          "CLK_DOMAIN": {
+            "value": "axi_ic_ACLK_0",
+            "value_src": "default"
+          },
+          "NUM_READ_THREADS": {
+            "value": "1",
+            "value_src": "default"
+          },
+          "NUM_WRITE_THREADS": {
+            "value": "1",
+            "value_src": "default"
+          },
+          "RUSER_BITS_PER_BYTE": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "WUSER_BITS_PER_BYTE": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "INSERT_VIP": {
+            "value": "0",
+            "value_src": "default"
+          }
+        }
+      },
+      "algo_axi": {
+        "mode": "Master",
+        "vlnv": "xilinx.com:interface:aximm_rtl:1.0",
+        "parameters": {
+          "DATA_WIDTH": {
+            "value": "64"
+          },
+          "PROTOCOL": {
+            "value": "AXI4"
+          },
+          "FREQ_HZ": {
+            "value": "125000000"
+          },
+          "ID_WIDTH": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "ADDR_WIDTH": {
+            "value": "64"
+          },
+          "AWUSER_WIDTH": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "ARUSER_WIDTH": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "WUSER_WIDTH": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "RUSER_WIDTH": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "BUSER_WIDTH": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "READ_WRITE_MODE": {
+            "value": "READ_WRITE",
+            "value_src": "default"
+          },
+          "HAS_BURST": {
+            "value": "1",
+            "value_src": "default"
+          },
+          "HAS_LOCK": {
+            "value": "1",
+            "value_src": "default"
+          },
+          "HAS_PROT": {
+            "value": "1",
+            "value_src": "default"
+          },
+          "HAS_CACHE": {
+            "value": "1",
+            "value_src": "default"
+          },
+          "HAS_QOS": {
+            "value": "0"
+          },
+          "HAS_REGION": {
+            "value": "0"
+          },
+          "HAS_WSTRB": {
+            "value": "1",
+            "value_src": "default"
+          },
+          "HAS_BRESP": {
+            "value": "1",
+            "value_src": "default"
+          },
+          "HAS_RRESP": {
+            "value": "1",
+            "value_src": "default"
+          },
+          "SUPPORTS_NARROW_BURST": {
+            "value": "1",
+            "value_src": "default"
+          },
+          "NUM_READ_OUTSTANDING": {
+            "value": "2"
+          },
+          "NUM_WRITE_OUTSTANDING": {
+            "value": "2"
+          },
+          "MAX_BURST_LENGTH": {
+            "value": "256",
+            "value_src": "default"
+          },
+          "PHASE": {
+            "value": "0.000",
+            "value_src": "default"
+          },
+          "CLK_DOMAIN": {
+            "value": "axi_ic_ACLK_0",
+            "value_src": "default"
+          },
+          "NUM_READ_THREADS": {
+            "value": "1",
+            "value_src": "default"
+          },
+          "NUM_WRITE_THREADS": {
+            "value": "1",
+            "value_src": "default"
+          },
+          "RUSER_BITS_PER_BYTE": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "WUSER_BITS_PER_BYTE": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "INSERT_VIP": {
+            "value": "0",
+            "value_src": "default"
+          }
+        }
+      }
+    },
+    "ports": {
+      "pcie_axi_aclk": {
+        "type": "clk",
+        "direction": "I",
+        "parameters": {
+          "ASSOCIATED_BUSIF": {
+            "value": "pcie_axi:ipb_axi:algo_axi"
+          },
+          "ASSOCIATED_RESET": {
+            "value": "S_ARESETN:pcie_axi_aresetn"
+          },
+          "CLK_DOMAIN": {
+            "value": "axi_ic_ACLK_0",
+            "value_src": "default"
+          },
+          "FREQ_HZ": {
+            "value": "125000000"
+          },
+          "INSERT_VIP": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "PHASE": {
+            "value": "0.000",
+            "value_src": "default"
+          }
+        }
+      },
+      "pcie_axi_aresetn": {
+        "type": "rst",
+        "direction": "I",
+        "parameters": {
+          "INSERT_VIP": {
+            "value": "0",
+            "value_src": "default"
+          },
+          "POLARITY": {
+            "value": "ACTIVE_LOW",
+            "value_src": "default"
+          }
+        }
+      }
+    },
+    "components": {
+      "axi_ic_0": {
+        "vlnv": "xilinx.com:ip:axi_interconnect:2.1",
+        "xci_name": "axi_ic_axi_ic_0_0",
+        "interface_ports": {
+          "S00_AXI": {
+            "mode": "Slave",
+            "vlnv": "xilinx.com:interface:aximm_rtl:1.0"
+          },
+          "M00_AXI": {
+            "mode": "Master",
+            "vlnv": "xilinx.com:interface:aximm_rtl:1.0"
+          },
+          "M01_AXI": {
+            "mode": "Master",
+            "vlnv": "xilinx.com:interface:aximm_rtl:1.0"
+          }
+        },
+        "ports": {
+          "ACLK": {
+            "type": "clk",
+            "direction": "I",
+            "parameters": {
+              "ASSOCIATED_RESET": {
+                "value": "ARESETN"
+              }
+            }
+          },
+          "ARESETN": {
+            "type": "rst",
+            "direction": "I"
+          },
+          "S00_ACLK": {
+            "type": "clk",
+            "direction": "I",
+            "parameters": {
+              "ASSOCIATED_BUSIF": {
+                "value": "S00_AXI"
+              },
+              "ASSOCIATED_RESET": {
+                "value": "S00_ARESETN"
+              }
+            }
+          },
+          "S00_ARESETN": {
+            "type": "rst",
+            "direction": "I"
+          },
+          "M00_ACLK": {
+            "type": "clk",
+            "direction": "I",
+            "parameters": {
+              "ASSOCIATED_BUSIF": {
+                "value": "M00_AXI"
+              },
+              "ASSOCIATED_RESET": {
+                "value": "M00_ARESETN"
+              }
+            }
+          },
+          "M00_ARESETN": {
+            "type": "rst",
+            "direction": "I"
+          },
+          "M01_ACLK": {
+            "type": "clk",
+            "direction": "I",
+            "parameters": {
+              "ASSOCIATED_BUSIF": {
+                "value": "M01_AXI"
+              },
+              "ASSOCIATED_RESET": {
+                "value": "M01_ARESETN"
+              }
+            }
+          },
+          "M01_ARESETN": {
+            "type": "rst",
+            "direction": "I"
+          }
+        },
+        "components": {
+          "xbar": {
+            "vlnv": "xilinx.com:ip:axi_crossbar:2.1",
+            "xci_name": "axi_ic_xbar_0",
+            "parameters": {
+              "NUM_MI": {
+                "value": "2"
+              },
+              "NUM_SI": {
+                "value": "1"
+              },
+              "STRATEGY": {
+                "value": "0"
+              }
+            }
+          },
+          "s00_couplers": {
+            "interface_ports": {
+              "M_AXI": {
+                "mode": "Master",
+                "vlnv": "xilinx.com:interface:aximm_rtl:1.0"
+              },
+              "S_AXI": {
+                "mode": "Slave",
+                "vlnv": "xilinx.com:interface:aximm_rtl:1.0"
+              }
+            },
+            "ports": {
+              "M_ACLK": {
+                "type": "clk",
+                "direction": "I",
+                "parameters": {
+                  "ASSOCIATED_BUSIF": {
+                    "value": "M_AXI"
+                  },
+                  "ASSOCIATED_RESET": {
+                    "value": "M_ARESETN"
+                  }
+                }
+              },
+              "M_ARESETN": {
+                "type": "rst",
+                "direction": "I"
+              },
+              "S_ACLK": {
+                "type": "clk",
+                "direction": "I",
+                "parameters": {
+                  "ASSOCIATED_BUSIF": {
+                    "value": "S_AXI"
+                  },
+                  "ASSOCIATED_RESET": {
+                    "value": "S_ARESETN"
+                  }
+                }
+              },
+              "S_ARESETN": {
+                "type": "rst",
+                "direction": "I"
+              }
+            },
+            "interface_nets": {
+              "s00_couplers_to_s00_couplers": {
+                "interface_ports": [
+                  "S_AXI",
+                  "M_AXI"
+                ]
+              }
+            }
+          },
+          "m00_couplers": {
+            "interface_ports": {
+              "M_AXI": {
+                "mode": "Master",
+                "vlnv": "xilinx.com:interface:aximm_rtl:1.0"
+              },
+              "S_AXI": {
+                "mode": "Slave",
+                "vlnv": "xilinx.com:interface:aximm_rtl:1.0"
+              }
+            },
+            "ports": {
+              "M_ACLK": {
+                "type": "clk",
+                "direction": "I",
+                "parameters": {
+                  "ASSOCIATED_BUSIF": {
+                    "value": "M_AXI"
+                  },
+                  "ASSOCIATED_RESET": {
+                    "value": "M_ARESETN"
+                  }
+                }
+              },
+              "M_ARESETN": {
+                "type": "rst",
+                "direction": "I"
+              },
+              "S_ACLK": {
+                "type": "clk",
+                "direction": "I",
+                "parameters": {
+                  "ASSOCIATED_BUSIF": {
+                    "value": "S_AXI"
+                  },
+                  "ASSOCIATED_RESET": {
+                    "value": "S_ARESETN"
+                  }
+                }
+              },
+              "S_ARESETN": {
+                "type": "rst",
+                "direction": "I"
+              }
+            },
+            "interface_nets": {
+              "m00_couplers_to_m00_couplers": {
+                "interface_ports": [
+                  "S_AXI",
+                  "M_AXI"
+                ]
+              }
+            }
+          },
+          "m01_couplers": {
+            "interface_ports": {
+              "M_AXI": {
+                "mode": "Master",
+                "vlnv": "xilinx.com:interface:aximm_rtl:1.0"
+              },
+              "S_AXI": {
+                "mode": "Slave",
+                "vlnv": "xilinx.com:interface:aximm_rtl:1.0"
+              }
+            },
+            "ports": {
+              "M_ACLK": {
+                "type": "clk",
+                "direction": "I",
+                "parameters": {
+                  "ASSOCIATED_BUSIF": {
+                    "value": "M_AXI"
+                  },
+                  "ASSOCIATED_RESET": {
+                    "value": "M_ARESETN"
+                  }
+                }
+              },
+              "M_ARESETN": {
+                "type": "rst",
+                "direction": "I"
+              },
+              "S_ACLK": {
+                "type": "clk",
+                "direction": "I",
+                "parameters": {
+                  "ASSOCIATED_BUSIF": {
+                    "value": "S_AXI"
+                  },
+                  "ASSOCIATED_RESET": {
+                    "value": "S_ARESETN"
+                  }
+                }
+              },
+              "S_ARESETN": {
+                "type": "rst",
+                "direction": "I"
+              }
+            },
+            "interface_nets": {
+              "m01_couplers_to_m01_couplers": {
+                "interface_ports": [
+                  "S_AXI",
+                  "M_AXI"
+                ]
+              }
+            }
+          }
+        },
+        "interface_nets": {
+          "m01_couplers_to_axi_ic_0": {
+            "interface_ports": [
+              "M01_AXI",
+              "m01_couplers/M_AXI"
+            ]
+          },
+          "xbar_to_m01_couplers": {
+            "interface_ports": [
+              "xbar/M01_AXI",
+              "m01_couplers/S_AXI"
+            ]
+          },
+          "axi_ic_0_to_s00_couplers": {
+            "interface_ports": [
+              "S00_AXI",
+              "s00_couplers/S_AXI"
+            ]
+          },
+          "s00_couplers_to_xbar": {
+            "interface_ports": [
+              "s00_couplers/M_AXI",
+              "xbar/S00_AXI"
+            ]
+          },
+          "m00_couplers_to_axi_ic_0": {
+            "interface_ports": [
+              "M00_AXI",
+              "m00_couplers/M_AXI"
+            ]
+          },
+          "xbar_to_m00_couplers": {
+            "interface_ports": [
+              "xbar/M00_AXI",
+              "m00_couplers/S_AXI"
+            ]
+          }
+        },
+        "nets": {
+          "axi_ic_0_ACLK_net": {
+            "ports": [
+              "ACLK",
+              "xbar/aclk",
+              "s00_couplers/S_ACLK",
+              "s00_couplers/M_ACLK",
+              "m00_couplers/M_ACLK",
+              "m01_couplers/M_ACLK",
+              "m00_couplers/S_ACLK",
+              "m01_couplers/S_ACLK"
+            ]
+          },
+          "axi_ic_0_ARESETN_net": {
+            "ports": [
+              "ARESETN",
+              "xbar/aresetn",
+              "s00_couplers/S_ARESETN",
+              "s00_couplers/M_ARESETN",
+              "m00_couplers/M_ARESETN",
+              "m01_couplers/M_ARESETN",
+              "m00_couplers/S_ARESETN",
+              "m01_couplers/S_ARESETN"
+            ]
+          }
+        }
+      }
+    },
+    "interface_nets": {
+      "S00_AXI_0_1": {
+        "interface_ports": [
+          "pcie_axi",
+          "axi_ic_0/S00_AXI"
+        ]
+      },
+      "axi_interconnect_0_M00_AXI": {
+        "interface_ports": [
+          "ipb_axi",
+          "axi_ic_0/M00_AXI"
+        ]
+      },
+      "axi_interconnect_0_M01_AXI": {
+        "interface_ports": [
+          "algo_axi",
+          "axi_ic_0/M01_AXI"
+        ]
+      }
+    },
+    "nets": {
+      "ACLK_0_1": {
+        "ports": [
+          "pcie_axi_aclk",
+          "axi_ic_0/ACLK",
+          "axi_ic_0/S00_ACLK",
+          "axi_ic_0/M00_ACLK",
+          "axi_ic_0/M01_ACLK"
+        ]
+      },
+      "ARESETN_0_1": {
+        "ports": [
+          "pcie_axi_aresetn",
+          "axi_ic_0/ARESETN",
+          "axi_ic_0/S00_ARESETN",
+          "axi_ic_0/M00_ARESETN",
+          "axi_ic_0/M01_ARESETN"
+        ]
+      }
+    },
+    "addressing": {
+      "/": {
+        "address_spaces": {
+          "pcie_axi": {
+            "range": "16E",
+            "width": "32",
+            "segments": {
+              "SEG_algo_axi_Reg": {
+                "address_block": "/algo_axi/Reg",
+                "offset": "0x0000000008000000",
+                "range": "128M"
+              },
+              "SEG_ipb_axi_Reg": {
+                "address_block": "/ipb_axi/Reg",
+                "offset": "0x0000000000000000",
+                "range": "128M"
+              }
+            }
+          }
+        },
+        "memory_maps": {
+          "ipb_axi": {
+            "address_blocks": {
+              "Reg": {
+                "base_address": "0",
+                "range": "64K",
+                "width": "32",
+                "usage": "register"
+              }
+            }
+          },
+          "algo_axi": {
+            "address_blocks": {
+              "Reg": {
+                "base_address": "0",
+                "range": "64K",
+                "width": "32",
+                "usage": "register"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/components/ipbus_transport_axi/firmware/cfg/add_block_designs.tcl
+++ b/components/ipbus_transport_axi/firmware/cfg/add_block_designs.tcl
@@ -1,0 +1,12 @@
+
+set script_path [ file dirname [ file normalize [ info script ] ] ]
+
+set bd_files [list ${script_path}/../bd/axi_ic/axi_ic.bd]
+
+foreach file_path ${bd_files} {
+  set bd_file_path [import_files ${file_path}]
+  open_bd_design ${bd_file_path}
+  reset_target {synthesis implementation} [get_files ${bd_file_path}]
+  generate_target {synthesis implementation} [get_files ${bd_file_path}]
+}
+

--- a/components/ipbus_transport_axi/firmware/cfg/ipbus_transport_axi.dep
+++ b/components/ipbus_transport_axi/firmware/cfg/ipbus_transport_axi.dep
@@ -23,7 +23,9 @@
 #
 #-------------------------------------------------------------------------------
 
+setup -f add_block_designs.tcl
 
+src axi_ic_top.vhd
 src ipbus_transport_axi_if.vhd
 
 src ipbus_transport_ram_if.vhd
@@ -31,7 +33,7 @@ src ipbus_transport_multibuffer_if.vhd
 src ipbus_transport_multibuffer_cdc.vhd
 src ipbus_transport_multibuffer_rx_dpram.vhd ipbus_transport_multibuffer_tx_dpram.vhd
 
-src ipbus_axi_decl.vhd
+src --vhdl2008 ipbus_axi_decl.vhd
 
 ? toolset.lower() == "vivado" ? src ../cgn/axi_bram_ctrl_0.xci
 

--- a/components/ipbus_transport_axi/firmware/hdl/axi_ic_top.vhd
+++ b/components/ipbus_transport_axi/firmware/hdl/axi_ic_top.vhd
@@ -1,0 +1,228 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use work.ipbus_axi_decl.all;
+
+entity axi_ic_top is
+  port (
+  pcie_axi_ms  : in  axi4mm_ms(araddr(63 downto 0), awaddr(63 downto 0), wdata(63 downto 0));
+  pcie_axi_sm  : out axi4mm_sm(rdata (63 downto 0));
+  --
+  algo_axi_ms  : out axi4mm_ms(araddr(63 downto 0), awaddr(63 downto 0), wdata(63 downto 0));
+  algo_axi_sm  : in  axi4mm_sm(rdata (63 downto 0));
+  ipb_axi_ms   : out axi4mm_ms(araddr(63 downto 0), awaddr(63 downto 0), wdata(63 downto 0));
+  ipb_axi_sm   : in  axi4mm_sm(rdata (63 downto 0))
+  );
+end axi_ic_top;
+
+architecture structure of axi_ic_top is
+  component axi_ic is
+  port (
+    pcie_axi_aclk : in std_logic;
+    pcie_axi_aresetn : in std_logic;
+    pcie_axi_awaddr : in std_logic_vector ( 63 downto 0 );
+    pcie_axi_awlen : in std_logic_vector ( 7 downto 0 );
+    pcie_axi_awsize : in std_logic_vector ( 2 downto 0 );
+    pcie_axi_awburst : in std_logic_vector ( 1 downto 0 );
+    pcie_axi_awlock : in std_logic_vector ( 0 to 0 );
+    pcie_axi_awcache : in std_logic_vector ( 3 downto 0 );
+    pcie_axi_awprot : in std_logic_vector ( 2 downto 0 );
+    pcie_axi_awvalid : in std_logic_vector ( 0 to 0 );
+    pcie_axi_awready : out std_logic_vector ( 0 to 0 );
+    pcie_axi_wdata : in std_logic_vector ( 63 downto 0 );
+    pcie_axi_wstrb : in std_logic_vector ( 7 downto 0 );
+    pcie_axi_wlast : in std_logic_vector ( 0 to 0 );
+    pcie_axi_wvalid : in std_logic_vector ( 0 to 0 );
+    pcie_axi_wready : out std_logic_vector ( 0 to 0 );
+    pcie_axi_bresp : out std_logic_vector ( 1 downto 0 );
+    pcie_axi_bvalid : out std_logic_vector ( 0 to 0 );
+    pcie_axi_bready : in std_logic_vector ( 0 to 0 );
+    pcie_axi_araddr : in std_logic_vector ( 63 downto 0 );
+    pcie_axi_arlen : in std_logic_vector ( 7 downto 0 );
+    pcie_axi_arsize : in std_logic_vector ( 2 downto 0 );
+    pcie_axi_arburst : in std_logic_vector ( 1 downto 0 );
+    pcie_axi_arlock : in std_logic_vector ( 0 to 0 );
+    pcie_axi_arcache : in std_logic_vector ( 3 downto 0 );
+    pcie_axi_arprot : in std_logic_vector ( 2 downto 0 );
+    pcie_axi_arvalid : in std_logic_vector ( 0 to 0 );
+    pcie_axi_arready : out std_logic_vector ( 0 to 0 );
+    pcie_axi_rdata : out std_logic_vector ( 63 downto 0 );
+    pcie_axi_rresp : out std_logic_vector ( 1 downto 0 );
+    pcie_axi_rlast : out std_logic_vector ( 0 to 0 );
+    pcie_axi_rvalid : out std_logic_vector ( 0 to 0 );
+    pcie_axi_rready : in std_logic_vector ( 0 to 0 );
+    ipb_axi_awaddr : out std_logic_vector ( 63 downto 0 );
+    ipb_axi_awlen : out std_logic_vector ( 7 downto 0 );
+    ipb_axi_awsize : out std_logic_vector ( 2 downto 0 );
+    ipb_axi_awburst : out std_logic_vector ( 1 downto 0 );
+    ipb_axi_awlock : out std_logic_vector ( 0 to 0 );
+    ipb_axi_awcache : out std_logic_vector ( 3 downto 0 );
+    ipb_axi_awprot : out std_logic_vector ( 2 downto 0 );
+    ipb_axi_awregion : out std_logic_vector ( 3 downto 0 );
+    ipb_axi_awvalid : out std_logic_vector ( 0 to 0 );
+    ipb_axi_awready : in std_logic_vector ( 0 to 0 );
+    ipb_axi_wdata : out std_logic_vector ( 63 downto 0 );
+    ipb_axi_wstrb : out std_logic_vector ( 7 downto 0 );
+    ipb_axi_wlast : out std_logic_vector ( 0 to 0 );
+    ipb_axi_wvalid : out std_logic_vector ( 0 to 0 );
+    ipb_axi_wready : in std_logic_vector ( 0 to 0 );
+    ipb_axi_bresp : in std_logic_vector ( 1 downto 0 );
+    ipb_axi_bvalid : in std_logic_vector ( 0 to 0 );
+    ipb_axi_bready : out std_logic_vector ( 0 to 0 );
+    ipb_axi_araddr : out std_logic_vector ( 63 downto 0 );
+    ipb_axi_arlen : out std_logic_vector ( 7 downto 0 );
+    ipb_axi_arsize : out std_logic_vector ( 2 downto 0 );
+    ipb_axi_arburst : out std_logic_vector ( 1 downto 0 );
+    ipb_axi_arlock : out std_logic_vector ( 0 to 0 );
+    ipb_axi_arcache : out std_logic_vector ( 3 downto 0 );
+    ipb_axi_arprot : out std_logic_vector ( 2 downto 0 );
+    ipb_axi_arqos : out std_logic_vector ( 3 downto 0 );
+    ipb_axi_arvalid : out std_logic_vector ( 0 to 0 );
+    ipb_axi_arready : in std_logic_vector ( 0 to 0 );
+    ipb_axi_rdata : in std_logic_vector ( 63 downto 0 );
+    ipb_axi_rresp : in std_logic_vector ( 1 downto 0 );
+    ipb_axi_rlast : in std_logic_vector ( 0 to 0 );
+    ipb_axi_rvalid : in std_logic_vector ( 0 to 0 );
+    ipb_axi_rready : out std_logic_vector ( 0 to 0 );
+    algo_axi_awaddr : out std_logic_vector ( 63 downto 0 );
+    algo_axi_awlen : out std_logic_vector ( 7 downto 0 );
+    algo_axi_awsize : out std_logic_vector ( 2 downto 0 );
+    algo_axi_awburst : out std_logic_vector ( 1 downto 0 );
+    algo_axi_awlock : out std_logic_vector ( 0 to 0 );
+    algo_axi_awcache : out std_logic_vector ( 3 downto 0 );
+    algo_axi_awprot : out std_logic_vector ( 2 downto 0 );
+    algo_axi_awqos : out std_logic_vector ( 3 downto 0 );
+    algo_axi_awvalid : out std_logic_vector ( 0 to 0 );
+    algo_axi_awready : in std_logic_vector ( 0 to 0 );
+    algo_axi_wdata : out std_logic_vector ( 63 downto 0 );
+    algo_axi_wstrb : out std_logic_vector ( 7 downto 0 );
+    algo_axi_wlast : out std_logic_vector ( 0 to 0 );
+    algo_axi_wvalid : out std_logic_vector ( 0 to 0 );
+    algo_axi_wready : in std_logic_vector ( 0 to 0 );
+    algo_axi_bresp : in std_logic_vector ( 1 downto 0 );
+    algo_axi_bvalid : in std_logic_vector ( 0 to 0 );
+    algo_axi_bready : out std_logic_vector ( 0 to 0 );
+    algo_axi_araddr : out std_logic_vector ( 63 downto 0 );
+    algo_axi_arlen : out std_logic_vector ( 7 downto 0 );
+    algo_axi_arsize : out std_logic_vector ( 2 downto 0 );
+    algo_axi_arburst : out std_logic_vector ( 1 downto 0 );
+    algo_axi_arlock : out std_logic_vector ( 0 to 0 );
+    algo_axi_arcache : out std_logic_vector ( 3 downto 0 );
+    algo_axi_arprot : out std_logic_vector ( 2 downto 0 );
+    algo_axi_arqos : out std_logic_vector ( 3 downto 0 );
+    algo_axi_arvalid : out std_logic_vector ( 0 to 0 );
+    algo_axi_arready : in std_logic_vector ( 0 to 0 );
+    algo_axi_rdata : in std_logic_vector ( 63 downto 0 );
+    algo_axi_rresp : in std_logic_vector ( 1 downto 0 );
+    algo_axi_rlast : in std_logic_vector ( 0 to 0 );
+    algo_axi_rvalid : in std_logic_vector ( 0 to 0 );
+    algo_axi_rready : out std_logic_vector ( 0 to 0 )
+  );
+  end component axi_ic;
+begin
+axi_ic_i: component axi_ic
+     port map (
+      algo_axi_araddr(63 downto 0)  => algo_axi_ms.araddr(63 downto 0),
+      algo_axi_arburst(1 downto 0)  => algo_axi_ms.arburst(1 downto 0),
+      algo_axi_arcache(3 downto 0)  => algo_axi_ms.arcache(3 downto 0),
+      algo_axi_arlen(7 downto 0)    => algo_axi_ms.arlen(7 downto 0),
+      algo_axi_arlock(0)            => algo_axi_ms.arlock,
+      algo_axi_arprot(2 downto 0)   => algo_axi_ms.arprot(2 downto 0),
+      algo_axi_arready(0)           => algo_axi_sm.arready,
+      algo_axi_arsize(2 downto 0)   => algo_axi_ms.arsize(2 downto 0),
+      algo_axi_arvalid(0)           => algo_axi_ms.arvalid,
+      algo_axi_awaddr(63 downto 0)  => algo_axi_ms.awaddr(63 downto 0),
+      algo_axi_awburst(1 downto 0)  => algo_axi_ms.awburst(1 downto 0),
+      algo_axi_awcache(3 downto 0)  => algo_axi_ms.awcache(3 downto 0),
+      algo_axi_awlen(7 downto 0)    => algo_axi_ms.awlen(7 downto 0),
+      algo_axi_awlock(0)            => algo_axi_ms.awlock,
+      algo_axi_awprot(2 downto 0)   => algo_axi_ms.awprot(2 downto 0),
+      algo_axi_awready(0)           => algo_axi_sm.awready,
+      algo_axi_awsize(2 downto 0)   => algo_axi_ms.awsize(2 downto 0),
+      algo_axi_awvalid(0)           => algo_axi_ms.awvalid,
+      algo_axi_bready(0)            => algo_axi_ms.bready,
+      algo_axi_bresp(1 downto 0)    => algo_axi_sm.bresp(1 downto 0),
+      algo_axi_bvalid(0)            => algo_axi_sm.bvalid,
+      algo_axi_rdata(63 downto 0)   => algo_axi_sm.rdata(63 downto 0),
+      algo_axi_rlast(0)             => algo_axi_sm.rlast,
+      algo_axi_rready(0)            => algo_axi_ms.rready,
+      algo_axi_rresp(1 downto 0)    => algo_axi_sm.rresp(1 downto 0),
+      algo_axi_rvalid(0)            => algo_axi_sm.rvalid,
+      algo_axi_wdata(63 downto 0)   => algo_axi_ms.wdata(63 downto 0),
+      algo_axi_wlast(0)             => algo_axi_ms.wlast,
+      algo_axi_wready(0)            => algo_axi_sm.wready,
+      algo_axi_wstrb(7 downto 0)    => algo_axi_ms.wstrb(7 downto 0),
+      algo_axi_wvalid(0)            => algo_axi_ms.wvalid,
+      --
+      ipb_axi_araddr(63 downto 0)   => ipb_axi_ms.araddr(63 downto 0),
+      ipb_axi_arburst(1 downto 0)   => ipb_axi_ms.arburst(1 downto 0),
+      ipb_axi_arcache(3 downto 0)   => ipb_axi_ms.arcache(3 downto 0),
+      ipb_axi_arlen(7 downto 0)     => ipb_axi_ms.arlen(7 downto 0),
+      ipb_axi_arlock(0)             => ipb_axi_ms.arlock,
+      ipb_axi_arprot(2 downto 0)    => ipb_axi_ms.arprot(2 downto 0),
+      ipb_axi_arready(0)            => ipb_axi_sm.arready,
+      ipb_axi_arsize(2 downto 0)    => ipb_axi_ms.arsize(2 downto 0),
+      ipb_axi_arvalid(0)            => ipb_axi_ms.arvalid,
+      ipb_axi_awaddr(63 downto 0)   => ipb_axi_ms.awaddr(63 downto 0),
+      ipb_axi_awburst(1 downto 0)   => ipb_axi_ms.awburst(1 downto 0),
+      ipb_axi_awcache(3 downto 0)   => ipb_axi_ms.awcache(3 downto 0),
+      ipb_axi_awlen(7 downto 0)     => ipb_axi_ms.awlen(7 downto 0),
+      ipb_axi_awlock(0)             => ipb_axi_ms.awlock,
+      ipb_axi_awprot(2 downto 0)    => ipb_axi_ms.awprot(2 downto 0),
+      ipb_axi_awready(0)            => ipb_axi_sm.awready,
+      ipb_axi_awsize(2 downto 0)    => ipb_axi_ms.awsize(2 downto 0),
+      ipb_axi_awvalid(0)            => ipb_axi_ms.awvalid,
+      ipb_axi_bready(0)             => ipb_axi_ms.bready,
+      ipb_axi_bresp(1 downto 0)     => ipb_axi_sm.bresp(1 downto 0),
+      ipb_axi_bvalid(0)             => ipb_axi_sm.bvalid,
+      ipb_axi_rdata(63 downto 0)    => ipb_axi_sm.rdata(63 downto 0),
+      ipb_axi_rlast(0)              => ipb_axi_sm.rlast,
+      ipb_axi_rready(0)             => ipb_axi_ms.rready,
+      ipb_axi_rresp(1 downto 0)     => ipb_axi_sm.rresp(1 downto 0),
+      ipb_axi_rvalid(0)             => ipb_axi_sm.rvalid,
+      ipb_axi_wdata(63 downto 0)    => ipb_axi_ms.wdata(63 downto 0),
+      ipb_axi_wlast(0)              => ipb_axi_ms.wlast,
+      ipb_axi_wready(0)             => ipb_axi_sm.wready,
+      ipb_axi_wstrb(7 downto 0)     => ipb_axi_ms.wstrb(7 downto 0),
+      ipb_axi_wvalid(0)             => ipb_axi_ms.wvalid,
+      --
+      pcie_axi_aclk                 => pcie_axi_ms.aclk,
+      pcie_axi_araddr(63 downto 0)  => pcie_axi_ms.araddr(63 downto 0),
+      pcie_axi_arburst(1 downto 0)  => pcie_axi_ms.arburst(1 downto 0),
+      pcie_axi_arcache(3 downto 0)  => pcie_axi_ms.arcache(3 downto 0),
+      pcie_axi_aresetn              => pcie_axi_ms.aresetn,
+      pcie_axi_arlen(7 downto 0)    => pcie_axi_ms.arlen(7 downto 0),
+      pcie_axi_arlock(0)            => pcie_axi_ms.arlock,
+      pcie_axi_arprot(2 downto 0)   => pcie_axi_ms.arprot(2 downto 0),
+      pcie_axi_arready(0)           => pcie_axi_sm.arready,
+      pcie_axi_arsize(2 downto 0)   => pcie_axi_ms.arsize(2 downto 0),
+      pcie_axi_arvalid(0)           => pcie_axi_ms.arvalid,
+      pcie_axi_awaddr(63 downto 0)  => pcie_axi_ms.awaddr(63 downto 0),
+      pcie_axi_awburst(1 downto 0)  => pcie_axi_ms.awburst(1 downto 0),
+      pcie_axi_awcache(3 downto 0)  => pcie_axi_ms.awcache(3 downto 0),
+      pcie_axi_awlen(7 downto 0)    => pcie_axi_ms.awlen(7 downto 0),
+      pcie_axi_awlock(0)            => pcie_axi_ms.awlock,
+      pcie_axi_awprot(2 downto 0)   => pcie_axi_ms.awprot(2 downto 0),
+      pcie_axi_awready(0)           => pcie_axi_sm.awready,
+      pcie_axi_awsize(2 downto 0)   => pcie_axi_ms.awsize(2 downto 0),
+      pcie_axi_awvalid(0)           => pcie_axi_ms.awvalid,
+      pcie_axi_bready(0)            => pcie_axi_ms.bready,
+      pcie_axi_bresp(1 downto 0)    => pcie_axi_sm.bresp(1 downto 0),
+      pcie_axi_bvalid(0)            => pcie_axi_sm.bvalid,
+      pcie_axi_rdata(63 downto 0)   => pcie_axi_sm.rdata(63 downto 0),
+      pcie_axi_rlast(0)             => pcie_axi_sm.rlast,
+      pcie_axi_rready(0)            => pcie_axi_ms.rready,
+      pcie_axi_rresp(1 downto 0)    => pcie_axi_sm.rresp(1 downto 0),
+      pcie_axi_rvalid(0)            => pcie_axi_sm.rvalid,
+      pcie_axi_wdata(63 downto 0)   => pcie_axi_ms.wdata(63 downto 0),
+      pcie_axi_wlast(0)             => pcie_axi_ms.wlast,
+      pcie_axi_wready(0)            => pcie_axi_sm.wready,
+      pcie_axi_wstrb(7 downto 0)    => pcie_axi_ms.wstrb(7 downto 0),
+      pcie_axi_wvalid(0)            => pcie_axi_ms.wvalid
+    );
+      -- aclk & aresetn forwarding
+      ipb_axi_ms.aclk               <= pcie_axi_ms.aclk;
+      ipb_axi_ms.aresetn            <= pcie_axi_ms.aresetn;
+      algo_axi_ms.aclk              <= pcie_axi_ms.aclk;
+      algo_axi_ms.aresetn           <= pcie_axi_ms.aresetn;
+
+end structure;

--- a/components/ipbus_transport_axi/firmware/hdl/ipbus_axi_decl.vhd
+++ b/components/ipbus_transport_axi/firmware/hdl/ipbus_axi_decl.vhd
@@ -29,7 +29,7 @@
 -- Defines records for AXI4 interface
 --
 -- Tom Williams, April 2018
-
+-- edited by Paschalis Vichoudis(CERN) to add AXI NULL constants [2021.04.19]
 
 library IEEE;
 use IEEE.STD_LOGIC_1164.all;
@@ -104,5 +104,49 @@ package ipbus_axi_decl is
 
 		end record;
 
+	constant AXI4MM_MS_NULL: axi4mm_ms(araddr(63 downto 0), awaddr(63 downto 0), wdata(63 downto 0)):=
+	    (
+			aclk    => '0',
+			aresetn => '0',
+            araddr  => (others => '0'),
+			arid    => (others => '0'),
+			arlen   => (others => '0'),
+			arsize  => (others => '0'),
+			arprot  => (others => '0'),
+			arvalid => '0',
+			arlock  => '0',
+			arcache => (others => '0'),
+			arburst => (others => '0'),
+			rready  => '0',
+			awaddr  => (others => '0'),
+			awid    => (others => '0'),
+			awlen   => (others => '0'),
+			awsize  => (others => '0'),
+			awburst => (others => '0'),
+			awprot  => (others => '0'),
+			awvalid => '0',
+			awlock  => '0',
+			awcache => (others => '0'),
+			wdata   => (others => '0'),
+			wlast   => '0',
+			wstrb   => (others => '0'),
+			wvalid  => '0',
+			bready  => '0'
+        );
 
+	constant AXI4MM_SM_NULL: axi4mm_sm(rdata(63 downto 0)):=
+	    (		
+	        arready => '0',
+            rdata   => (others => '0'),
+			rid     => (others => '0'),
+			rresp   => (others => '0'),
+			rlast   => '0',
+			rvalid  => '0',
+			awready => '0',
+			wready  => '0',
+			bvalid  => '0',
+			bresp   => (others => '0'),
+			bid     => (others => '0')
+        );
+		
 end ipbus_axi_decl;


### PR DESCRIPTION
This branch is required in order to use the axi_bus implementation in EMP (branch axi_bus).
More details in that merge request.