### PR TITLE
VCU118 SGMII example design: Fix termination settings of clock pins

### DIFF
--- a/boards/vcu118/sgmii/synth/firmware/ucf/eth.tcl
+++ b/boards/vcu118/sgmii/synth/firmware/ucf/eth.tcl
@@ -7,6 +7,10 @@ set_property IOSTANDARD LVDS [get_ports sgmii_clk_p]
 set_property IOSTANDARD LVDS [get_ports sgmii_clk_n]
 set_property PACKAGE_PIN AT22 [get_ports sgmii_clk_p]
 set_property PACKAGE_PIN AU22 [get_ports sgmii_clk_n]
+# Differential pair not terminated, so following settings needed to avoid reflection that
+# would degrade the clock until the Ethernet connection is lost (Credit: Javier Sastre)
+set_property DIFF_TERM_ADV TERM_100 [get_ports sgmii_clk_p]
+set_property DIFF_TERM_ADV TERM_100 [get_ports sgmii_clk_n]
 
  
 ############  Receive Pins 


### PR DESCRIPTION
This branch is a fix from Javier Sastre for a problem with the Ethernet connection in the VCU118 SGMII design.

Description of the symptoms:
> Just when the board is programmed, FPGA starts PHY configuration and I’m able to ping the board, but just only for a few seconds. Then, I lose link and I have to reset the board.

Description of the fix:
> The constraints file boards/vcu118/sgmii/synth/firmware/ucf/eth.tcl  includes the activation of the differential termination of sgmii_rx. However, sgmii_clk diff pair is not terminated. Just after PHY configuration, this one starts sending the clk to the fpga. Because this line is not terminated, this induces reflections that degrade the clock until losing connection.
>
> I’ve included the following lines and I’ve got an stable connection:
> 
> set_property DIFF_TERM_ADV TERM_100 [get_ports sgmii_clk_p]
> set_property DIFF_TERM_ADV TERM_100 [get_ports sgmii_clk_n] 

All credit for fix should go to Javier Sastre
