### PR TITLE
Feature improve freq ctr

### DIFF
--- a/components/ipbus_slaves/firmware/hdl/ipbus_freq_ctr.vhd
+++ b/components/ipbus_slaves/firmware/hdl/ipbus_freq_ctr.vhd
@@ -28,8 +28,15 @@
 --
 -- General clock frequency monitor (slightly advanced version).
 --
--- Just like the original ipbus_freq_ctr, but with a dedicated reference clock
--- for the counters, instead of relying on the IPBus clock.
+-- Optimised to measure a large number of clocks, without requiring large resources
+-- in each local clock domain (e.g. for monitoring transceiver clocks).
+--
+-- Counts number of pulses of the (divided by 64) clock in 16M cycles of ipbus clock
+-- Should deal with clocks between 1MHz and ~320MHz.
+--
+-- This version is just like the original ipbus_freq_ctr, but with a
+-- dedicated reference clock for the counters, instead of relying on
+-- the IPBus clock.
 
 --------------------------------------------------------------------------------
 

--- a/components/ipbus_slaves/firmware/hdl/ipbus_freq_ctr.vhd
+++ b/components/ipbus_slaves/firmware/hdl/ipbus_freq_ctr.vhd
@@ -1,46 +1,21 @@
----------------------------------------------------------------------------------
---
---   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
---
---   Licensed under the Apache License, Version 2.0 (the "License");
---   you may not use this file except in compliance with the License.
---   You may obtain a copy of the License at
---
---       http://www.apache.org/licenses/LICENSE-2.0
---
---   Unless required by applicable law or agreed to in writing, software
---   distributed under the License is distributed on an "AS IS" BASIS,
---   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
---   See the License for the specific language governing permissions and
---   limitations under the License.
---
---                                     - - -
---
---   Additional information about ipbus-firmare and the list of ipbus-firmware
---   contacts are available at
---
---       https://ipbus.web.cern.ch/ipbus
---
----------------------------------------------------------------------------------
-
+--------------------------------------------------------------------------------
 
 -- ipbus_freq_ctr
 --
--- General clock frequency monitor
+-- General clock frequency monitor (slightly advanced version).
 --
--- Optimised to measure a large number of clocks, without requiring large resources
--- in each local clock domain (e.g. for monitoring transceiver clocks)
---
--- Counts number of pulses of the (divided by 64) clock in 16M cycles of ipbus clock
--- Should deal with clocks between 1MHz and ~320MHz
---
--- Dave Newbold, September 2013
+-- Just like the original ipbus_freq_ctr, but with a dedicated reference clock
+-- for the counters, instead of relying on the IPBus clock.
+
+--------------------------------------------------------------------------------
 
 library IEEE;
 use IEEE.STD_LOGIC_1164.ALL;
 use ieee.numeric_std.all;
+
 use work.ipbus.all;
 use work.ipbus_reg_types.all;
+
 library unisim;
 use unisim.VComponents.all;
 
@@ -49,6 +24,7 @@ entity ipbus_freq_ctr is
 		N_CLK: natural := 1
 	);
 	port(
+		clk_ref: in std_logic;
 		clk: in std_logic;
 		rst: in std_logic;
 		ipb_in: in ipb_wbus;
@@ -98,18 +74,18 @@ begin
 	cd(N_CLK - 1 downto 0) <= clkdiv;
 	cd(2 ** ADDR_WIDTH - 1 downto N_CLK) <= (others => '0');
 	
-	process(clk) -- Synchroniser
+	process(clk_ref) -- Synchroniser
 	begin
-		if rising_edge(clk) then
+		if rising_edge(clk_ref) then
 			t_in <= cd(sel);
 			t <= t_in;
 			t_d <= t;
 		end if;
 	end process;
 	
-	process(clk) -- Counters
+	process(clk_ref) -- Counters
 	begin
-		if rising_edge(clk) then
+		if rising_edge(clk_ref) then
 		
 			ctr <= ctr + 1;
 
@@ -135,3 +111,5 @@ begin
 		"0000000" & svalid & std_logic_vector(sctr(15 downto 0)) & X"00";
 	
 end rtl;
+
+--------------------------------------------------------------------------------

--- a/components/ipbus_slaves/firmware/hdl/ipbus_freq_ctr.vhd
+++ b/components/ipbus_slaves/firmware/hdl/ipbus_freq_ctr.vhd
@@ -1,4 +1,28 @@
---------------------------------------------------------------------------------
+---------------------------------------------------------------------------------
+--
+--   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
+--
+--   Licensed under the Apache License, Version 2.0 (the "License");
+--   you may not use this file except in compliance with the License.
+--   You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--   Unless required by applicable law or agreed to in writing, software
+--   distributed under the License is distributed on an "AS IS" BASIS,
+--   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--   See the License for the specific language governing permissions and
+--   limitations under the License.
+--
+--                                     - - -
+--
+--   Additional information about ipbus-firmare and the list of ipbus-firmware
+--   contacts are available at
+--
+--       https://ipbus.web.cern.ch/ipbus
+--
+---------------------------------------------------------------------------------
+
 
 -- ipbus_freq_ctr
 --


### PR DESCRIPTION
Recent experience shows that the exact frequency of the IPBus clock
differs from board to board. This is no surprise, really, because
this clock tends to be derived from PCIe, AXI, etc. clocks which
are not necessarily very precise. It has a visible effect, though,
on the frequencies reported by ipbus_freq_ctr, which uses the IPBus
clock as reference.

The current modification adds a separate reference clock input to
ipbus_freq_ctr, so that a more precise clock can be used if so desired.

NOTE: This does imply an interface change. There now is a new input
port clk_ref to be connected.