### PR TITLE
Frequency counter with separate reference clock

### DIFF
--- a/components/ipbus_slaves/firmware/cfg/ipbus_freq_ctr_adv.dep
+++ b/components/ipbus_slaves/firmware/cfg/ipbus_freq_ctr_adv.dep
@@ -24,7 +24,7 @@
 #-------------------------------------------------------------------------------
 
 
-src freq_ctr_div.vhd ipbus_freq_ctr.vhd ipbus_freq_ctr_core.vhd ipbus_ctrlreg_v.vhd
+src freq_ctr_div.vhd ipbus_freq_ctr_adv.vhd ipbus_freq_ctr_core.vhd ipbus_ctrlreg_v.vhd
 addrtab ipbus_freq_ctr.xml
 src ipbus_reg_types.vhd
 src -c components/ipbus_core ipbus_package.vhd

--- a/components/ipbus_slaves/firmware/hdl/ipbus_freq_ctr.vhd
+++ b/components/ipbus_slaves/firmware/hdl/ipbus_freq_ctr.vhd
@@ -28,8 +28,15 @@
 --
 -- General clock frequency monitor (slightly advanced version).
 --
--- Just like the original ipbus_freq_ctr, but with a dedicated reference clock
--- for the counters, instead of relying on the IPBus clock.
+-- Optimised to measure a large number of clocks, without requiring large resources
+-- in each local clock domain (e.g. for monitoring transceiver clocks).
+--
+-- Counts number of pulses of the (divided by 64) clock in 16M cycles of ipbus clock
+-- Should deal with clocks between 1MHz and ~320MHz.
+--
+-- This version is just like the original ipbus_freq_ctr, but with a
+-- dedicated reference clock for the counters, instead of relying on
+-- the IPBus clock.
 
 --------------------------------------------------------------------------------
 

--- a/components/ipbus_slaves/firmware/hdl/ipbus_freq_ctr.vhd
+++ b/components/ipbus_slaves/firmware/hdl/ipbus_freq_ctr.vhd
@@ -1,46 +1,21 @@
----------------------------------------------------------------------------------
---
---   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
---
---   Licensed under the Apache License, Version 2.0 (the "License");
---   you may not use this file except in compliance with the License.
---   You may obtain a copy of the License at
---
---       http://www.apache.org/licenses/LICENSE-2.0
---
---   Unless required by applicable law or agreed to in writing, software
---   distributed under the License is distributed on an "AS IS" BASIS,
---   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
---   See the License for the specific language governing permissions and
---   limitations under the License.
---
---                                     - - -
---
---   Additional information about ipbus-firmare and the list of ipbus-firmware
---   contacts are available at
---
---       https://ipbus.web.cern.ch/ipbus
---
----------------------------------------------------------------------------------
-
+--------------------------------------------------------------------------------
 
 -- ipbus_freq_ctr
 --
--- General clock frequency monitor
+-- General clock frequency monitor (slightly advanced version).
 --
--- Optimised to measure a large number of clocks, without requiring large resources
--- in each local clock domain (e.g. for monitoring transceiver clocks)
---
--- Counts number of pulses of the (divided by 64) clock in 16M cycles of ipbus clock
--- Should deal with clocks between 1MHz and ~320MHz
---
--- Dave Newbold, September 2013
+-- Just like the original ipbus_freq_ctr, but with a dedicated reference clock
+-- for the counters, instead of relying on the IPBus clock.
+
+--------------------------------------------------------------------------------
 
 library IEEE;
 use IEEE.STD_LOGIC_1164.ALL;
 use ieee.numeric_std.all;
+
 use work.ipbus.all;
 use work.ipbus_reg_types.all;
+
 library unisim;
 use unisim.VComponents.all;
 
@@ -49,6 +24,7 @@ entity ipbus_freq_ctr is
 		N_CLK: natural := 1
 	);
 	port(
+		clk_ref: in std_logic;
 		clk: in std_logic;
 		rst: in std_logic;
 		ipb_in: in ipb_wbus;
@@ -98,18 +74,18 @@ begin
 	cd(N_CLK - 1 downto 0) <= clkdiv;
 	cd(2 ** ADDR_WIDTH - 1 downto N_CLK) <= (others => '0');
 	
-	process(clk) -- Synchroniser
+	process(clk_ref) -- Synchroniser
 	begin
-		if rising_edge(clk) then
+		if rising_edge(clk_ref) then
 			t_in <= cd(sel);
 			t <= t_in;
 			t_d <= t;
 		end if;
 	end process;
 	
-	process(clk) -- Counters
+	process(clk_ref) -- Counters
 	begin
-		if rising_edge(clk) then
+		if rising_edge(clk_ref) then
 		
 			ctr <= ctr + 1;
 
@@ -135,3 +111,5 @@ begin
 		"0000000" & svalid & std_logic_vector(sctr(15 downto 0)) & X"00";
 	
 end rtl;
+
+--------------------------------------------------------------------------------

--- a/components/ipbus_slaves/firmware/hdl/ipbus_freq_ctr.vhd
+++ b/components/ipbus_slaves/firmware/hdl/ipbus_freq_ctr.vhd
@@ -1,4 +1,28 @@
---------------------------------------------------------------------------------
+---------------------------------------------------------------------------------
+--
+--   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
+--
+--   Licensed under the Apache License, Version 2.0 (the "License");
+--   you may not use this file except in compliance with the License.
+--   You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--   Unless required by applicable law or agreed to in writing, software
+--   distributed under the License is distributed on an "AS IS" BASIS,
+--   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--   See the License for the specific language governing permissions and
+--   limitations under the License.
+--
+--                                     - - -
+--
+--   Additional information about ipbus-firmare and the list of ipbus-firmware
+--   contacts are available at
+--
+--       https://ipbus.web.cern.ch/ipbus
+--
+---------------------------------------------------------------------------------
+
 
 -- ipbus_freq_ctr
 --

--- a/components/ipbus_slaves/firmware/hdl/ipbus_freq_ctr_adv.vhd
+++ b/components/ipbus_slaves/firmware/hdl/ipbus_freq_ctr_adv.vhd
@@ -55,6 +55,7 @@ entity ipbus_freq_ctr is
 		N_CLK: natural := 1
 	);
 	port(
+		clk_ref: in std_logic;
 		clk: in std_logic;
 		rst: in std_logic;
 		ipb_in: in ipb_wbus;
@@ -71,28 +72,28 @@ architecture rtl of ipbus_freq_ctr is
 
 begin
 
-	reg: entity work.ipbus_ctrlreg_v
+	reg: entity work.ipbus_syncreg_v
 		generic map(
 			N_CTRL => 1,
 			N_STAT => 1
 		)
 		port map(
 			clk => clk,
-			reset => rst,
-			ipbus_in => ipb_in,
-			ipbus_out => ipb_out,
+			rst => rst,
+			ipb_in => ipb_in,
+			ipb_out => ipb_out,
+			slv_clk => clk_ref,
 			d => stat,
-			q => ctrl
+			q => ctrl,
+			stb(0) => cyc
 		);
-		
-	cyc <= ipb_in.ipb_strobe and ipb_in.ipb_write and not ipb_in.ipb_addr(0);
 
 	freq_ctr: entity work.ipbus_freq_ctr_core
 		generic map(
 			N_CLK => N_CLK
 		)
 		port map(
-			clk_ref => clk,
+			clk_ref => clk_ref,
 			ctrl_cyc => cyc,
 			ctrl => ctrl(0),
 			stat => stat(0),

--- a/components/ipbus_slaves/firmware/hdl/ipbus_freq_ctr_core.vhd
+++ b/components/ipbus_slaves/firmware/hdl/ipbus_freq_ctr_core.vhd
@@ -26,7 +26,7 @@
 
 -- ipbus_freq_ctr
 --
--- General clock frequency monitor (slightly advanced version).
+-- General clock frequency monitor (core component).
 --
 -- Optimised to measure a large number of clocks, without requiring large resources
 -- in each local clock domain (e.g. for monitoring transceiver clocks).
@@ -50,55 +50,80 @@ use work.ipbus_reg_types.all;
 library unisim;
 use unisim.VComponents.all;
 
-entity ipbus_freq_ctr is
+entity ipbus_freq_ctr_core is
 	generic(
 		N_CLK: natural := 1
 	);
 	port(
-		clk: in std_logic;
-		rst: in std_logic;
-		ipb_in: in ipb_wbus;
-		ipb_out: out ipb_rbus;
+		clk_ref: in std_logic;
+		ctrl_cyc: in std_logic;
+		ctrl: in std_logic_vector(31 downto 0);
+		stat: out std_logic_vector(31 downto 0);
 		clkdiv: in std_logic_vector(N_CLK - 1 downto 0)
 	);
-	
-end ipbus_freq_ctr;
-
-architecture rtl of ipbus_freq_ctr is
-
-	signal stat, ctrl: ipb_reg_v(0 downto 0);
-	signal cyc: std_logic;
 
 begin
 
-	reg: entity work.ipbus_ctrlreg_v
-		generic map(
-			N_CTRL => 1,
-			N_STAT => 1
-		)
-		port map(
-			clk => clk,
-			reset => rst,
-			ipbus_in => ipb_in,
-			ipbus_out => ipb_out,
-			d => stat,
-			q => ctrl
-		);
+	assert N_CLK <= 16
+		report "Too many clocks for freq_ctr"
+		severity failure;
+
+end ipbus_freq_ctr_core;
+
+architecture rtl of ipbus_freq_ctr_core is
+
+	constant ADDR_WIDTH: integer := calc_width(N_CLK);
+	signal sel: integer range 0 to 2 ** ADDR_WIDTH - 1 := 0;
+	signal ctr, tctr, sctr: unsigned(23 downto 0) := X"000000";
+	signal cd: std_logic_vector(2 ** ADDR_WIDTH - 1 downto 0) := (others => '0');
+	signal t_in, t, t_d, valid, svalid: std_logic;
+	
+	attribute SHREG_EXTRACT: string;
+	attribute SHREG_EXTRACT of t_in: signal is "no"; -- Synchroniser not to be optimised into shreg
+
+begin
 		
-	cyc <= ipb_in.ipb_strobe and ipb_in.ipb_write and not ipb_in.ipb_addr(0);
+	sel <= to_integer(unsigned(ctrl(ADDR_WIDTH - 1 downto 0))) when ADDR_WIDTH > 0 else 0;
+	
+	cd(N_CLK - 1 downto 0) <= clkdiv;
+	cd(2 ** ADDR_WIDTH - 1 downto N_CLK) <= (others => '0');
+	
+	process(clk_ref) -- Synchroniser
+	begin
+		if rising_edge(clk_ref) then
+			t_in <= cd(sel);
+			t <= t_in;
+			t_d <= t;
+		end if;
+	end process;
+	
+	process(clk_ref) -- Counters
+	begin
+		if rising_edge(clk_ref) then
+		
+			ctr <= ctr + 1;
 
-	freq_ctr: entity work.ipbus_freq_ctr_core
-		generic map(
-			N_CLK => N_CLK
-		)
-		port map(
-			clk_ref => clk,
-			ctrl_cyc => cyc,
-			ctrl => ctrl(0),
-			stat => stat(0),
-			clkdiv => clkdiv
-		);
+			if ctr = X"000000" or (ctr(15 downto 0) = X"0000" and ctrl(4) = '1') then
+				sctr <= tctr;
+				tctr <= X"000000";
+			elsif t = '1' and t_d = '0' then
+				tctr <= tctr + 1;
+			end if;
 
+			if ctr = X"000000" then
+				svalid <= valid;
+				valid <= '1';
+			elsif ctrl_cyc = '1' then
+				svalid <= '0';
+				valid <= '0';
+			end if;
+				
+		end if;
+	end process;
+	
+	stat <= "0000000" & svalid & std_logic_vector(sctr) when ctrl(4) = '0' else
+		"0000000" & svalid & std_logic_vector(sctr(15 downto 0)) & X"00";
+	
 end rtl;
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This is a refactorisation of merge request #217 from @jhegeman - the separate reference clock is now supported in a new entity `ipbus_freq_ctr_adv`, which has a `syncreg` rather than a plain `ctrlreg` since typically the reference clock would be unrelated to the IPbus clock.

Original description from !217:

> Recent experience shows that the exact frequency of the IPBus clock differs from board to board. This is no surprise, really, because this clock tends to be derived from PCIe, AXI, etc. clocks which are not necessarily very precise. It has a visible effect, though, on the frequencies reported by ipbus_freq_ctr, which uses the IPBus clock as reference.
> 
> The current modification adds a separate reference clock input to ipbus_freq_ctr, so that a more precise clock can be used if so desired.
> 
> NOTE: This does imply an interface change. There now is a new input port clk_ref to be connected.
