### PR TITLE
Fix the oscillator clock frequency in the VCU118 SGMII infrastructure

### DIFF
--- a/boards/vcu118/sgmii/synth/firmware/hdl/vcu118_infra_sgmii.vhd
+++ b/boards/vcu118/sgmii/synth/firmware/hdl/vcu118_infra_sgmii.vhd
@@ -119,7 +119,8 @@ begin
     --  DCM clock generation for internal bus, ethernet
     clocks : entity work.clocks_usp_serdes
         generic map (
-            CLK_FR_FREQ => 300.0
+            CLK_FR_FREQ => 300.0,
+            CLK_VCO_FREQ => 1200.0
             )
         port map (
             clki_fr       => osc_clk_300,


### PR DESCRIPTION
The frequency of the VCO clock frequency in the VCU118 SGMII infrastructure is incorrect. This leads to complaints from Vivado about:
[DRC AVAL-168] MMCM_ADV Phase shift and divide attr checks: The MMCME4_ADV cell infra/clocks/mmcm has a fractional CLKFBOUT_MULT_F value (3.333) which is not a multiple of the hardware granularity (0.125) and will be adjusted to the nearest supportable value. Please update the design to use a valid value.

This patch fixes that by correcting the MMCME4 generic values provided in the infrastructure code.

The above can be easily reproduced (using Vivado 2021.2) by building the top_vcu118_sgmii.dep example.