### PR TITLE
Remove spurious includes of the led_stretcher

### DIFF
--- a/boards/vcu118/pcie/synth/firmware/cfg/vcu118_infra_pcie.dep
+++ b/boards/vcu118/pcie/synth/firmware/cfg/vcu118_infra_pcie.dep
@@ -32,7 +32,6 @@
 
 
 src vcu118_infra_pcie.vhd
-src -c components/ipbus_util clocks/clocks_usp_serdes.vhd ipbus_clock_div.vhd led_stretcher.vhd
 include -c components/ipbus_pcie ipbus_pcie_xdma_usp.dep
 include -c components/ipbus_transport_axi
 src -c components/ipbus_core ipbus_fabric_sel.vhd ipbus_package.vhd

--- a/boards/vcu118/sgmii/synth/firmware/cfg/vcu118_infra_sgmii.dep
+++ b/boards/vcu118/sgmii/synth/firmware/cfg/vcu118_infra_sgmii.dep
@@ -32,7 +32,6 @@
 
 
 src vcu118_infra_sgmii.vhd
-src -c components/ipbus_util clocks/clocks_usp_serdes.vhd ipbus_clock_div.vhd led_stretcher.vhd
 include -c components/ipbus_util ipbus_ctrl.dep
 include eth_sgmii_lvds_vcu118.dep
 src -c components/ipbus_core ipbus_fabric_sel.vhd ipbus_package.vhd


### PR DESCRIPTION
The led_stretcher component is not used in the VCU118 infrastructure, so there is no need to include it into the Vivado projects.