### PR TITLE
Fix a few inconsistencies in the inline documentation

### DIFF
--- a/components/ipbus_util/addr_table/ipbus_sysmon_us_ext_ref.xml
+++ b/components/ipbus_util/addr_table/ipbus_sysmon_us_ext_ref.xml
@@ -2,9 +2,9 @@
 
 <node fwinfo="endpoint; width=8">
 
-  <!-- NOTE: Since the lower nine bits of the address are passed
+  <!-- NOTE: Since the lower eight bits of the address are passed
        straigh to the DRP side of the sysmon, one should not
-       instantiate the IPBus sysmon entity below address 0x200. -->
+       instantiate the IPBus sysmon entity below address 0x100. -->
 
   <!-- More details about the actual register contents can be found in
        Xilinx UG580. -->

--- a/components/ipbus_util/addr_table/ipbus_sysmon_us_int_ref.xml
+++ b/components/ipbus_util/addr_table/ipbus_sysmon_us_int_ref.xml
@@ -2,9 +2,9 @@
 
 <node fwinfo="endpoint; width=8">
 
-  <!-- NOTE: Since the lower nine bits of the address are passed
+  <!-- NOTE: Since the lower eight bits of the address are passed
        straigh to the DRP side of the sysmon, one should not
-       instantiate the IPBus sysmon entity below address 0x200. -->
+       instantiate the IPBus sysmon entity below address 0x100. -->
 
   <!-- More details about the actual register contents can be found in
        Xilinx UG580. -->

--- a/components/ipbus_util/addr_table/ipbus_sysmon_usp_ext_ref.xml
+++ b/components/ipbus_util/addr_table/ipbus_sysmon_usp_ext_ref.xml
@@ -2,9 +2,9 @@
 
 <node fwinfo="endpoint; width=8">
 
-  <!-- NOTE: Since the lower nine bits of the address are passed
+  <!-- NOTE: Since the lower eight bits of the address are passed
        straigh to the DRP side of the sysmon, one should not
-       instantiate the IPBus sysmon entity below address 0x200. -->
+       instantiate the IPBus sysmon entity below address 0x100. -->
 
   <!-- More details about the actual register contents can be found in
        Xilinx UG580. -->

--- a/components/ipbus_util/addr_table/ipbus_sysmon_usp_int_ref.xml
+++ b/components/ipbus_util/addr_table/ipbus_sysmon_usp_int_ref.xml
@@ -2,9 +2,9 @@
 
 <node fwinfo="endpoint; width=8">
 
-  <!-- NOTE: Since the lower nine bits of the address are passed
+  <!-- NOTE: Since the lower eight bits of the address are passed
        straigh to the DRP side of the sysmon, one should not
-       instantiate the IPBus sysmon entity below address 0x200. -->
+       instantiate the IPBus sysmon entity below address 0x100. -->
 
   <!-- More details about the actual register contents can be found in
        Xilinx UG580. -->

--- a/components/ipbus_util/addr_table/ipbus_sysmon_x7.xml
+++ b/components/ipbus_util/addr_table/ipbus_sysmon_x7.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 
-<node fwinfo="endpoint; width=8">
+<node fwinfo="endpoint; width=7">
 
-  <!-- NOTE: Since the lower nine bits of the address are passed
+  <!-- NOTE: Since the lower seven bits of the address are passed
        straigh to the DRP side of the sysmon, one should not
-       instantiate the IPBus sysmon entity below address 0x200. -->
+       instantiate the IPBus sysmon entity below address 0x80. -->
 
   <!-- More details about the actual register contents can be found in
        Xilinx UG480. -->


### PR DESCRIPTION
Fix a few inconsistencies in the inline documentation (in the address tables) for the sysmon components