### PR TITLE
Add some 'missing' ipbb dependency files

### DIFF
--- a/components/ipbus_core/firmware/cfg/ipbus_fabric_sel.dep
+++ b/components/ipbus_core/firmware/cfg/ipbus_fabric_sel.dep
@@ -1,0 +1,29 @@
+#-------------------------------------------------------------------------------
+#
+#   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#                                     - - -
+#
+#   Additional information about ipbus-firmare and the list of ipbus-firmware
+#   contacts are available at
+#
+#       https://ipbus.web.cern.ch/ipbus
+#
+#-------------------------------------------------------------------------------
+
+
+src ipbus_fabric_sel.vhd
+
+include ipbus_package.dep

--- a/components/ipbus_core/firmware/cfg/ipbus_package.dep
+++ b/components/ipbus_core/firmware/cfg/ipbus_package.dep
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------------------------
+#
+#   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#                                     - - -
+#
+#   Additional information about ipbus-firmare and the list of ipbus-firmware
+#   contacts are available at
+#
+#       https://ipbus.web.cern.ch/ipbus
+#
+#-------------------------------------------------------------------------------
+
+
+src ipbus_package.vhd

--- a/components/ipbus_pcie/firmware/cfg/pcie_int_gen_msix.dep
+++ b/components/ipbus_pcie/firmware/cfg/pcie_int_gen_msix.dep
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------------------------
+#
+#   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#                                     - - -
+#
+#   Additional information about ipbus-firmare and the list of ipbus-firmware
+#   contacts are available at
+#
+#       https://ipbus.web.cern.ch/ipbus
+#
+#-------------------------------------------------------------------------------
+
+
+src pcie_int_gen_msix.vhd

--- a/components/ipbus_pcie/firmware/cfg/pcie_xdma_axi_usp_if.dep
+++ b/components/ipbus_pcie/firmware/cfg/pcie_xdma_axi_usp_if.dep
@@ -1,0 +1,29 @@
+#-------------------------------------------------------------------------------
+#
+#   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#                                     - - -
+#
+#   Additional information about ipbus-firmare and the list of ipbus-firmware
+#   contacts are available at
+#
+#       https://ipbus.web.cern.ch/ipbus
+#
+#-------------------------------------------------------------------------------
+
+
+src pcie_xdma_axi_usp_if.vhd
+
+include -c components/ipbus_transport_axi ipbus_axi_decl.dep

--- a/components/ipbus_slaves/firmware/cfg/axi4lite_interface.dep
+++ b/components/ipbus_slaves/firmware/cfg/axi4lite_interface.dep
@@ -1,0 +1,29 @@
+#-------------------------------------------------------------------------------
+#
+#   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#                                     - - -
+#
+#   Additional information about ipbus-firmare and the list of ipbus-firmware
+#   contacts are available at
+#
+#       https://ipbus.web.cern.ch/ipbus
+#
+#-------------------------------------------------------------------------------
+
+
+src     axi4lite_interface.vhd
+include -c components/ipbus_util ipbus_cdc_reg.dep
+include -c components/ipbus_util cdc_reset.dep

--- a/components/ipbus_slaves/firmware/cfg/drp_decl.dep
+++ b/components/ipbus_slaves/firmware/cfg/drp_decl.dep
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------------------------
+#
+#   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#                                     - - -
+#
+#   Additional information about ipbus-firmare and the list of ipbus-firmware
+#   contacts are available at
+#
+#       https://ipbus.web.cern.ch/ipbus
+#
+#-------------------------------------------------------------------------------
+
+
+src drp_decl.vhd

--- a/components/ipbus_slaves/firmware/cfg/ipbus_ported_dpram.dep
+++ b/components/ipbus_slaves/firmware/cfg/ipbus_ported_dpram.dep
@@ -1,0 +1,29 @@
+#-------------------------------------------------------------------------------
+#
+#   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#                                     - - -
+#
+#   Additional information about ipbus-firmare and the list of ipbus-firmware
+#   contacts are available at
+#
+#       https://ipbus.web.cern.ch/ipbus
+#
+#-------------------------------------------------------------------------------
+
+
+src ipbus_ported_dpram.vhd
+
+include -c components/ipbus_core ipbus_package.dep

--- a/components/ipbus_slaves/firmware/cfg/ipbus_reg_types.dep
+++ b/components/ipbus_slaves/firmware/cfg/ipbus_reg_types.dep
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------------------------
+#
+#   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#                                     - - -
+#
+#   Additional information about ipbus-firmare and the list of ipbus-firmware
+#   contacts are available at
+#
+#       https://ipbus.web.cern.ch/ipbus
+#
+#-------------------------------------------------------------------------------
+
+
+src ipbus_reg_types.vhd

--- a/components/ipbus_transport_axi/firmware/cfg/ipbus_axi_decl.dep
+++ b/components/ipbus_transport_axi/firmware/cfg/ipbus_axi_decl.dep
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------------------------
+#
+#   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#                                     - - -
+#
+#   Additional information about ipbus-firmare and the list of ipbus-firmware
+#   contacts are available at
+#
+#       https://ipbus.web.cern.ch/ipbus
+#
+#-------------------------------------------------------------------------------
+
+
+src ipbus_axi_decl.vhd

--- a/components/ipbus_util/firmware/cfg/cdc_reset.dep
+++ b/components/ipbus_util/firmware/cfg/cdc_reset.dep
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------------------------
+#
+#   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#                                     - - -
+#
+#   Additional information about ipbus-firmare and the list of ipbus-firmware
+#   contacts are available at
+#
+#       https://ipbus.web.cern.ch/ipbus
+#
+#-------------------------------------------------------------------------------
+
+
+src cdc_reset.vhd

--- a/components/ipbus_util/firmware/cfg/clocks/clocks_usp_serdes.dep
+++ b/components/ipbus_util/firmware/cfg/clocks/clocks_usp_serdes.dep
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------------------------
+#
+#   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#                                     - - -
+#
+#   Additional information about ipbus-firmare and the list of ipbus-firmware
+#   contacts are available at
+#
+#       https://ipbus.web.cern.ch/ipbus
+#
+#-------------------------------------------------------------------------------
+
+
+src clocks/clocks_usp_serdes.vhd

--- a/components/ipbus_util/firmware/cfg/ipbus_cdc_reg.dep
+++ b/components/ipbus_util/firmware/cfg/ipbus_cdc_reg.dep
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------------------------
+#
+#   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#                                     - - -
+#
+#   Additional information about ipbus-firmare and the list of ipbus-firmware
+#   contacts are available at
+#
+#       https://ipbus.web.cern.ch/ipbus
+#
+#-------------------------------------------------------------------------------
+
+
+src ipbus_cdc_reg.vhd

--- a/components/ipbus_util/firmware/cfg/ipbus_clock_div.dep
+++ b/components/ipbus_util/firmware/cfg/ipbus_clock_div.dep
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------------------------
+#
+#   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#                                     - - -
+#
+#   Additional information about ipbus-firmare and the list of ipbus-firmware
+#   contacts are available at
+#
+#       https://ipbus.web.cern.ch/ipbus
+#
+#-------------------------------------------------------------------------------
+
+
+src ipbus_clock_div.vhd

--- a/components/ipbus_util/firmware/cfg/led_stretcher.dep
+++ b/components/ipbus_util/firmware/cfg/led_stretcher.dep
@@ -1,0 +1,29 @@
+#-------------------------------------------------------------------------------
+#
+#   Copyright 2017 - Rutherford Appleton Laboratory and University of Bristol
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+#                                     - - -
+#
+#   Additional information about ipbus-firmare and the list of ipbus-firmware
+#   contacts are available at
+#
+#       https://ipbus.web.cern.ch/ipbus
+#
+#-------------------------------------------------------------------------------
+
+
+src led_stretcher.vhd
+
+include ipbus_clock_div.dep

--- a/tests/ci/check-dep-files.sh
+++ b/tests/ci/check-dep-files.sh
@@ -40,7 +40,7 @@ do
       TOOLSET=$([[ "${componentDir}/firmware/cfg/${depFile}" =~ "sim" ]] && echo "sim" || echo "vivado")
 
       echo "Checking ${componentDir} - ${depFile}   [tool: ${TOOLSET}]"
-      ipbb toolbox check-dep ${TOOLSET} ipbus-firmware:${componentDir} $(basename ${depFile})
+      ipbb toolbox check-dep ${TOOLSET} ipbus-firmware:${componentDir} ${depFile}
 
       if [ $? -ne 0 ]; then
         ((N_ERRORS++))


### PR DESCRIPTION
This is not an attempt to provide ipbb dependency files for _all_ packages and entities. It does, however, add several missing dependency files.

NOTE: The advantage of providing .dep files even for simple packages/entities is that it makes it possible to later on update the implementation (and the dependencies) without all downstream projects having to update their dependency files.