### PR TITLE
Disable the axi clock workaround for Vivado 2023.2+

### DIFF
--- a/components/ipbus_pcie/firmware/ucf/fix_axi_clk_freq.tcl
+++ b/components/ipbus_pcie/firmware/ucf/fix_axi_clk_freq.tcl
@@ -1,13 +1,15 @@
-# From Vivado 2020.2.2 (i.e. from IP core 4.1 revision 10) there
-# appears to be a bug which causes the AXI clock frequency to be half
+# From Vivado 2020.2.2 (i.e. from IP core 4.1 revision 10) to 2023.2
+# there was a bug which caused the AXI clock frequency to be half
 # of what was requested if the CPLL is being used. (See also:
-# https://gitlab.cern.ch/p2-xware/firmware/emp-fwk/-/issues/26.)
+# https://gitlab.cern.ch/p2-xware/firmware/emp-fwk/-/issues/26 and
+# https://gitlab.cern.ch/p2-xware/firmware/emp-fwk/-/merge_requests/163 )
 #
 # Until this gets fixed/solved upstream, we redefine the problem clock
 # with a modified constraint adapted from the IP core itself.
 
 if {([get_property IPDEF [get_ips xdma_0]] == "xilinx.com:ip:xdma:4.1")
     && ([get_property CORE_REVISION [get_ips xdma_0]] >= 10)
+    && ([get_property CORE_REVISION [get_ips xdma_0]] < 26)
     && ([get_property CONFIG.plltype [get_ips xdma_0]] == "CPLL")} {
   puts "Fixing up AXI clock frequency as workaround for a Vivado bug."
   # create_clock -period 2.000 -name xdma_txoutclk [get_pins -hierarchical -filter {NAME =~infra/dma/xdma/*/*_CHANNEL_PRIM_INST/TXOUTCLK}]


### PR DESCRIPTION
The workaround for the AXI clock CPLL bug from Vivado 2020.2.2 is not needed in Vivado 2023.2 or later.
So, it should probably be disabled as in https://gitlab.cern.ch/p2-xware/firmware/emp-fwk/-/merge_requests/163

To be honest, in emp my design for the dth v1p2 with vivado 2023.2 this code was not doing anything anyway because it was failing with `ERROR: [Vivado 12-4739] create_generated_clock:No valid object(s) found for '-master_clock [get_clocks pcie_sys_clk]'` so I don't know if this fix is really useful or not, but I stumbled on this when looking for another problem.

I made the PR for the branch reduce-sysmon-addr-decode-width because that's the one which emp is using when running with ipbus v1.16 and tcds v0.3 but I can rebase elsewhere if useful.

@jhegeman  @tswilliams 